### PR TITLE
Fix spellcheck repeating nested list nodes.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# Configurations to normalize the IDE behavior.
+# http://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = tab
+tab_width = 4
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/bender.js
+++ b/bender.js
@@ -47,8 +47,8 @@ var config = {
             applications: [ 'ckeditor' ],
             basePath: 'tests/',
             paths: [
-				'typowalking/**',
                 'smoke/**',
+				'typowalking/**',
                 '!**/_*/**'
             ],
             // Latest of the old API (1.8.3)

--- a/bender.js
+++ b/bender.js
@@ -47,6 +47,7 @@ var config = {
             applications: [ 'ckeditor' ],
             basePath: 'tests/',
             paths: [
+				'wordwalker/**',
                 'smoke/**',
                 '!**/_*/**'
             ],

--- a/bender.js
+++ b/bender.js
@@ -1,6 +1,6 @@
 /**
  * Bender configuration file
- * 
+ *
  * @param {Object}   applications       Applications used in current project
  * @param {Array}    browsers           List of browsers used for testing
  * @param {Number}   captureTimeout     Timeout before which a launched browser should connect to the server

--- a/bender.js
+++ b/bender.js
@@ -47,7 +47,7 @@ var config = {
             applications: [ 'ckeditor' ],
             basePath: 'tests/',
             paths: [
-				'wordwalker/**',
+				'typowalking/**',
                 'smoke/**',
                 '!**/_*/**'
             ],

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -39,8 +39,6 @@
 		return word.replace(/[\u2018\u2019]/g, "'");
 	}
 
-	// wordwalker definition
-
 	function WordWalker(range) {
 		// the WordWalker takes a range encompassing a block element
 		// (for example, p, li, td)

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -53,7 +53,11 @@
 		function evaluator(node) {
 			var path = new CKEDITOR.dom.elementPath( node, startNode );
 
-			return node.type == CKEDITOR.NODE_TEXT && node.getLength() > 0 && ( !node.isReadOnly() ) && isNotBookmark(node) && (path.block && path.block.equals(startNode));
+			return node.type == CKEDITOR.NODE_TEXT && // it is a text node
+				node.getLength() > 0 &&  // and it's not empty
+				( !node.isReadOnly() ) &&   // or read only
+				isNotBookmark(node) &&  // and isn't a fake bookmarking node
+				(path.block && path.block.equals(startNode)); // it's not nested in a deeper block from our root.
 		}
 
 		var walker = new CKEDITOR.dom.walker(range);

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -69,7 +69,7 @@
 		}
 
 		this.rootBlockTextNodeWalker = new CKEDITOR.dom.walker(range);
-		rootBlockTextNodeWalker.evaluator = isRootBlockTextNode;
+		this.rootBlockTextNodeWalker.evaluator = isRootBlockTextNode;
 
 		var wordSeparatorRegex = /[.,"'?!;: \u0085\u00a0\u1680\u280e\u2028\u2029\u202f\u205f\u3000]/;
 
@@ -80,14 +80,9 @@
 			return ( code >= 9 && code <= 0xd ) || ( code >= 0x2000 && code <= 0x200a ) || wordSeparatorRegex.test(character);
 		};
 
-		this.textNode = walker.next();
+		this.textNode = this.rootBlockTextNodeWalker.next();
 		this.offset = 0;
 		this.origRange = range;
-
-		this._ = {
-			walker: rootBlockTextNodeWalker,
-			isWordSeparator: isWordSeparator
-		}
 	}
 
 	WordWalker.prototype = {
@@ -96,7 +91,7 @@
 			length = text.length;
 
 			for (i = startIndex + 1; i < length; i++) {
-				if (!this._.isWordSeparator(text[i])) {
+				if (!this.isWordSeparator(text[i])) {
 					break;
 				}
 			}
@@ -125,7 +120,7 @@
 			while (currentTextNode !== null) {
 				text = currentTextNode.getText();
 				for (i = this.offset; i < text.length; i++) {
-					if (this._.isWordSeparator(text[i])) {
+					if (this.isWordSeparator(text[i])) {
 						word += text.substr(this.offset, i - this.offset);
 						wordRange.setEnd(currentTextNode, i);
 
@@ -140,7 +135,7 @@
 				word += text.substr(this.offset);
 				this.offset = 0;
 				wordRange.setEndAfter(this.textNode);
-				currentTextNode = this._.walker.next();
+				currentTextNode = this.rootBlockTextNodeWalker.next();
 
 				this.textNode = currentTextNode;
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -33,6 +33,10 @@
 		nosuggestions: "( No Spelling Suggestions )"
 	};
 
+	function cleanQuotes(word) {
+		return word.replace(/[\u2018\u2019]/g, "'");
+	};
+
 	// wordwalker definition
 
 	function WordWalker(range) {
@@ -501,7 +505,7 @@
 				}
 				for (var i = 0; i < matches.length; i++) {
 					var word = cleanQuotes(matches[i]);
-					if (!uniqueWords[word] && validWordToken(word) && (typeof(spellcache[word]) === 'undefined')) {
+					if (!uniqueWords[word] && self.validWordToken(word) && (typeof(spellcache[word]) === 'undefined')) {
 						words.push(word);
 						uniqueWords[word] = true;
 						if (words.length >= max) {
@@ -511,11 +515,6 @@
 				}
 				return words;
 			}
-
-			function cleanQuotes(word) {
-				return word.replace(/[\u2018\u2019]/g, "'");
-			}
-
 			function addPersonal(word) {
 				var value = localStorage.getItem('nano_spellchecker_personal');
 				if (value !== null && value !== "") {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -24,9 +24,6 @@
 	var editorHasFocus = false;
 	var spell_delay = 250;
 	var spell_fast_after_spacebar = true;
-	var this
-	.
-	settings;
 	var settings_path;
 	var state = false;
 	var lang = "en";

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -425,7 +425,7 @@
             function render() {
                 var bookmarks = editor.getSelection().createBookmarks();
                 clearAllSpellCheckingSpans(editor.editable());
-                MarkAllTypos();
+                self.markAllTypos(editor);
                 editor.getSelection().selectBookmarks(bookmarks);
 
                 editor.fire('SpellcheckStart');
@@ -571,19 +571,6 @@
                 return false;
             }
 
-            //# SECTION MARKUP #//
-            function MarkAllTypos(body) {
-                var range = editor.createRange(),
-                    block;
-
-                range.selectNodeContents(editor.editable());
-
-                var iterator = range.createIterator();
-                while (( block = iterator.getNextParagraph() )) {
-                    markTypos(block);
-                }
-            }
-
             function getSuggestions(word) {
                 word = cleanQuotes(word);
                 if (suggestionscache[word] && suggestionscache[word][0]) {
@@ -592,39 +579,6 @@
                     }
                 }
                 return suggestionscache[word];
-            }
-
-            function markTypos(node) {
-                var match;
-
-                var range = editor.createRange();
-                range.selectNodeContents(node);
-                var wordwalker = new self.WordWalker(range);
-
-                var badRanges = [];
-                var matchtext;
-
-
-                while ((match = wordwalker.getNextWord()) != null) {
-                    matchtext = match.word;
-
-                    if (!validWordToken(matchtext)) {
-                        continue;
-                    }
-                    if (typeof(suggestionscache[cleanQuotes(matchtext)]) !== 'object') {
-                        continue;
-                    }
-                    badRanges.push(match.range)
-
-                }
-
-                var rangeListIterator = (new CKEDITOR.dom.rangeList(badRanges)).createIterator();
-                var currRange;
-
-                while (currRange = rangeListIterator.getNextRange()) {
-                    wrapWithTypoSpan(currRange);
-                }
-
             }
 
             function wrapWithTypoSpan(range) {
@@ -783,6 +737,49 @@
                 removeFormatFilter.call(editor, removeFormatFilterTemplate);
             }
         },
+		markTypos: function(editor, node) {
+			var match;
+
+			var range = editor.createRange();
+			range.selectNodeContents(node);
+			var wordwalker = new this.WordWalker(range);
+
+			var badRanges = [];
+			var matchtext;
+
+
+			while ((match = wordwalker.getNextWord()) != null) {
+				matchtext = match.word;
+
+				if (!validWordToken(matchtext)) {
+					continue;
+				}
+				if (typeof(suggestionscache[cleanQuotes(matchtext)]) !== 'object') {
+					continue;
+				}
+				badRanges.push(match.range)
+
+			}
+
+			var rangeListIterator = (new CKEDITOR.dom.rangeList(badRanges)).createIterator();
+			var currRange;
+
+			while (currRange = rangeListIterator.getNextRange()) {
+				wrapWithTypoSpan(currRange);
+			}
+
+		},
+		markAllTypos: function(editor) {
+			var range = editor.createRange(),
+				block;
+
+			range.selectNodeContents(editor.editable());
+
+			var iterator = range.createIterator();
+			while (( block = iterator.getNextParagraph() )) {
+				this.markTypos(editor, block);
+			}
+		},
 		WordWalker: WordWalker
     });
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -134,6 +134,10 @@
 		init: function (editor) {
 			var self = this;
 
+			this.spellcache = [];
+			this.suggestionscache = [];
+			this.ignorecache = [];
+
 			this.addRule(editor);
 
 			overrideCheckDirty();
@@ -179,7 +183,7 @@
 				editorHasFocus = false;
 			});
 			editor.on("instanceReady", function () {
-				if (this.settings.autostart !== false) {
+				if (self.settings.autostart !== false) {
 					start()
 				}
 			});
@@ -408,7 +412,7 @@
 				for (var i in words) {
 					var word = words[i];
 					if (result[word]) {
-						suggestionscache[word] = result[word];
+						self.suggestionscache[word] = result[word];
 						spellcache[word] = false;
 					} else {
 						spellcache[word] = true;
@@ -512,10 +516,6 @@
 				return word.replace(/[\u2018\u2019]/g, "'");
 			}
 
-			var spellcache = [];
-			var suggestionscache = [];
-			var ignorecache = [];
-
 			function addPersonal(word) {
 				var value = localStorage.getItem('nano_spellchecker_personal');
 				if (value !== null && value !== "") {
@@ -529,12 +529,12 @@
 
 			function getSuggestions(word) {
 				word = cleanQuotes(word);
-				if (suggestionscache[word] && suggestionscache[word][0]) {
+				if (self.suggestionscache[word] && self.suggestionscache[word][0]) {
 					if (suggestionscache[word][0].indexOf("*") == 0) {
 						return ["nanospell\xA0plugin\xA0developer\xA0trial ", "ckeditor-spellcheck.nanospell.com/license\xA0"];
 					}
 				}
-				return suggestionscache[word];
+				return self.suggestionscache[word];
 			}
 
 			function wrapWithTypoSpan(range) {
@@ -728,7 +728,7 @@
 			if (ignoreNumeric && /\d/.test(word)) {
 				return false;
 			}
-			if (ignorecache[word.toLowerCase()]) {
+			if (this.ignorecache[word.toLowerCase()]) {
 				return false;
 			}
 			return !this.hasPersonal(word);
@@ -747,10 +747,10 @@
 			while ((match = wordwalker.getNextWord()) != null) {
 				matchtext = match.word;
 
-				if (!validWordToken(matchtext)) {
+				if (!this.validWordToken(matchtext)) {
 					continue;
 				}
-				if (typeof(suggestionscache[cleanQuotes(matchtext)]) !== 'object') {
+				if (typeof(this.suggestionscache[cleanQuotes(matchtext)]) !== 'object') {
 					continue;
 				}
 				badRanges.push(match.range)

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -137,7 +137,9 @@
 				this.textNode = currentTextNode;
 
 			}
-			// reached the end of paragraph
+			// reached the end of block,
+			// so just return what we've walked
+			// of the current word.
 
 			return {
 				word: word,

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -45,8 +45,15 @@
 	function WordWalker(range) {
 		var isNotBookmark = CKEDITOR.dom.walker.bookmark(false, true);
 
+		var startNode = range.startContainer;
+		var endNode = range.endContainer;
+
+		console.assert(startNode.equals(endNode));
+
 		function evaluator(node) {
-			return node.type == CKEDITOR.NODE_TEXT && node.getLength() > 0 && ( !node.isReadOnly() ) && isNotBookmark(node);
+			var path = new CKEDITOR.dom.elementPath( node, startNode );
+
+			return node.type == CKEDITOR.NODE_TEXT && node.getLength() > 0 && ( !node.isReadOnly() ) && isNotBookmark(node) && (path.block && path.block.equals(startNode));
 		}
 
 		var walker = new CKEDITOR.dom.walker(range);

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -54,7 +54,7 @@
 		function isRootBlockTextNode(node) {
 			// this function is an evaluator used to return only
 			// the text nodes in the walker.
-			// beacuse of a special case around nested lists,
+			// because of a special case around nested lists,
 			// non-root block nodes must also be excluded.
 			// the text content of ckeditor bookmarks must also be excluded
 			// or &nbsp; will be added throughout.

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -42,8 +42,13 @@
 
 	// wordwalker definition
 
-	function WordWalker(range) {
+	function WordWalker(range, origNode) {
 		var isNotBookmark = CKEDITOR.dom.walker.bookmark(false, true);
+		var blockBoundary = CKEDITOR.dom.walker.blockBoundary();
+
+		function guard(node) {
+			return !(blockBoundary(node) && node.equals(origNode));
+		}
 
 		function evaluator(node) {
 			return node.type == CKEDITOR.NODE_TEXT && node.getLength() > 0 && ( !node.isReadOnly() ) && isNotBookmark(node);
@@ -51,6 +56,7 @@
 
 		var walker = new CKEDITOR.dom.walker(range);
 		walker.evaluator = evaluator;
+		walker.guard = guard;
 
 		var wordSeparatorRegex = /[.,"'?!;: \u0085\u00a0\u1680\u280e\u2028\u2029\u202f\u205f\u3000]/;
 
@@ -736,7 +742,7 @@
 
 			var range = editor.createRange();
 			range.selectNodeContents(node);
-			var wordwalker = new this.WordWalker(range);
+			var wordwalker = new this.WordWalker(range, node);
 
 			var badRanges = [];
 			var matchtext;

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -42,13 +42,8 @@
 
 	// wordwalker definition
 
-	function WordWalker(range, origNode) {
+	function WordWalker(range) {
 		var isNotBookmark = CKEDITOR.dom.walker.bookmark(false, true);
-		var blockBoundary = CKEDITOR.dom.walker.blockBoundary();
-
-		function guard(node) {
-			return !(blockBoundary(node) && node.equals(origNode));
-		}
 
 		function evaluator(node) {
 			return node.type == CKEDITOR.NODE_TEXT && node.getLength() > 0 && ( !node.isReadOnly() ) && isNotBookmark(node);
@@ -56,7 +51,6 @@
 
 		var walker = new CKEDITOR.dom.walker(range);
 		walker.evaluator = evaluator;
-		walker.guard = guard;
 
 		var wordSeparatorRegex = /[.,"'?!;: \u0085\u00a0\u1680\u280e\u2028\u2029\u202f\u205f\u3000]/;
 
@@ -742,7 +736,7 @@
 
 			var range = editor.createRange();
 			range.selectNodeContents(node);
-			var wordwalker = new this.WordWalker(range, node);
+			var wordwalker = new this.WordWalker(range);
 
 			var badRanges = [];
 			var matchtext;

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -18,21 +18,23 @@
  * FCK and CKE have enabled a new generation of online software , without your excelent work this project would be pointless.
  */
 (function () {
-    'use strict';
+	'use strict';
 
-    var maxRequest = 200;
-    var editorHasFocus = false;
-    var spell_delay = 250;
-    var spell_fast_after_spacebar = true;
-    var settings;
-    var settings_path;
-    var state = false;
-    var lang = "en";
-    var locale = {
-        ignore: "Ignore",
-        learn: "Add To Personal Dictionary",
-        nosuggestions: "( No Spelling Suggestions )"
-    };
+	var maxRequest = 200;
+	var editorHasFocus = false;
+	var spell_delay = 250;
+	var spell_fast_after_spacebar = true;
+	var this
+	.
+	settings;
+	var settings_path;
+	var state = false;
+	var lang = "en";
+	var locale = {
+		ignore: "Ignore",
+		learn: "Add To Personal Dictionary",
+		nosuggestions: "( No Spelling Suggestions )"
+	};
 
 	// wordwalker definition
 
@@ -130,614 +132,611 @@
 		}
 	};
 
-    CKEDITOR.plugins.add('nanospell', {
-        icons: 'nanospell',
-        init: function (editor) {
+	CKEDITOR.plugins.add('nanospell', {
+		icons: 'nanospell',
+		init: function (editor) {
 			var self = this;
 
-            this.addRule(editor);
-
-            overrideCheckDirty();
-
-            settings_path = this.path;
-            if (editor && !editor.config.nanospell) {
-                editor.config.nanospell = {};
-            }
-            settings = editor.config.nanospell;
-            if (!settings) {
-                settings = {};
-            }
-            lang = settings.dictionary || lang;
-            editor.addCommand('nanospell', {
-                exec: function (editor) {
-                    if (!state) {
-                        start();
-                    } else {
-                        stop();
-                    }
-                },
-                editorFocus: true
-            });
-            editor.ui.addButton('nanospell', {
-                label: 'Spell Checking by Nanospell',
-                command: 'nanospell',
-                toolbar: 'nanospell',
-                icon: this.path + 'icons/nanospell.png'
-            });
-            editor.ui.addButton('Nanospell', {
-                label: 'Spell Checking by Nanospell',
-                command: 'nanospell',
-                toolbar: 'Nanospell',
-                icon: this.path + 'icons/nanospell.png'
-            });
-            editor.on("key", function (k) {
-                keyHandler(k.data.keyCode)
-            });
-            editor.on("focus", function () {
-                editorHasFocus = true;
-            });
-            editor.on("blur", function () {
-                editorHasFocus = false;
-            });
-            editor.on("instanceReady", function () {
-                if (settings.autostart !== false) {
-                    start()
-                }
-            });
-            editor.on('mode', function () {
-                if (editor.mode == 'wysiwyg' && state) {
-                    start()
-                }
-                return true;
-            });
-
-            setUpContextMenu(editor, this.path);
-
-
-            function setUpContextMenu(editor, path) {
-                var iconpath = path + 'icons/nanospell.png';
-                if (!editor.contextMenu) {
-                    setTimeout(function () {
-                        setUpContextMenu(editor, path)
-                    }, 100);
-                    return;
-                }
-                var generateSuggestionMenuItem = function (suggestion, icon, typo, element) {
-                    return {
-                        label: suggestion,
-                        icon: icon ? iconpath : null,
-                        group: 'nano',
-                        onClick: function () {
-                            if (suggestion.indexOf(String.fromCharCode(160)) > -1) {
-                                return window.open('http://ckeditor-spellcheck.nanospell.com/license?discount=developer_max');
-                            }
-
-                            element.setText(suggestion);
-                            // remove the wrapping span
-                            element.remove(true);
-                        }
-                    }
-                };
-                var currentTypoText = function () {
-                    var anchor = editor.getSelection().getStartElement();
-                    var range = editor.createRange();
-                    //Fixes FF and IE hilighting of selected word
-                    range.selectNodeContents(anchor);
-                    range.enlarge();
-                    range.optimize();
-                    range.select();
-                    // end fix
-                    return anchor.getText();
-                };
-
-                editor.addMenuGroup('nano', -10 * 3);
-                /*at the top*/
-                editor.addMenuGroup('nanotools', -10 * 3 + 1);
-                editor.contextMenu.addListener(function (element) {
-                    if (!element.$ || !element.$.className || element.$.nodeName.toLowerCase() != 'span' || element.$.className !== "nanospell-typo") {
-                        return;
-                    }
-                    var typo = currentTypoText();
-                    var retobj = {};
-                    var suggestions = getSuggestions(typo);
-                    if (!suggestions) {
-                        return;
-                    }
-                    if (suggestions.length == 0) {
-
-                        editor.addMenuItem('nanopell_nosug', {
-                            label: locale.nosuggestions,
-                            icon: iconpath,
-                            group: 'nano'
-                        });
-                        retobj["nanopell_nosug"] = CKEDITOR.TRISTATE_DISABLED
-                    } else {
-                        for (var i = 0; i < suggestions.length; i++) {
-                            var word = suggestions[i];
-                            if (word.replace(/^\s+|\s+$/g, '').length < 1) {
-                                continue;
-                            }
-                            editor.addMenuItem('nanopell_sug_' + i, generateSuggestionMenuItem(word, !i, typo, element));
-                            retobj["nanopell_sug_" + i] = CKEDITOR.TRISTATE_OFF;
-                        }
-                    }
-
-                    editor.addMenuItem('nanopell_ignore', {
-                        label: locale.ignore,
-                        group: 'nanotools',
-                        onClick: function () {
-                            ignoreWord(element.$, typo, true);
-                        }
-                    });
-
-                    retobj["nanopell_ignore"] = CKEDITOR.TRISTATE_OFF;
-                    //
-                    if (localStorage) {
-                        editor.addMenuItem('nanopell_learn', {
-                            label: locale.learn,
-                            group: 'nanotools',
-                            onClick: function () {
-                                addPersonal(typo);
-                                ignoreWord(element.$, typo, true);
-                            }
-                        });
-                        retobj["nanopell_learn"] = CKEDITOR.TRISTATE_OFF;
-                    }
-                    return retobj
-                });
-
-                appendCustomStyles(settings_path);
-            }
-
-            /* #2 setup layer */
-            /* #3 nanospell util layer */
-            var start = function () {
-                editor.getCommand('nanospell').setState(CKEDITOR.TRISTATE_ON);
-                state = true;
-                var words = getWords(editor.document.$.body, maxRequest);
-                if (words.length == 0) {
-                    render();
-                } else {
-                    send(words);
-                }
-            };
-            var stop = function () {
-                editor.getCommand('nanospell').setState(CKEDITOR.TRISTATE_OFF);
-                state = false;
-                clearAllSpellCheckingSpans(editor.editable());
-            };
-
-            function checkNow() {
-                if (!selectionCollapsed()) {
-                    return;
-                }
-                if (state) {
-                    start();
-                }
-            }
-
-            function elementAtCursor() {
-                if (!editor.getSelection()) {
-                    return null;
-                }
-                return editor.getSelection().getStartElement();
-            }
-
-            function keyHandler(ch8r) {
-                editorHasFocus = true;
-                //recheck after typing activity
-                if (ch8r >= 16 && ch8r <= 31) {
-                    return;
-                }
-                if (ch8r >= 37 && ch8r <= 40) {
-                    return;
-                }
-                var target = elementAtCursor();
-                if (!target) {
-                    return;
-                }
-
-                var elementPath = new CKEDITOR.dom.elementPath(target);
-
-                //if! user is typing on a typo remove its underline
-
-                var spellCheckSpan = elementPath.contains(isSpellCheckSpan);
-
-                if (spellCheckSpan) {
-                    var bookmarks = editor.getSelection().createBookmarks();
-                    unwrapTypoSpan(spellCheckSpan);
-                    editor.getSelection().selectBookmarks(bookmarks);
-                }
-
-                triggerSpelling((spell_fast_after_spacebar && (ch8r === 32 || ch8r === 10 || ch8r === 13)))
-            }
-
-            function isSpellCheckSpan(node) {
-                return node.getName() === 'span' && node.hasClass('nanospell-typo');
-            }
-
-            function send(words) {
-                var url = resolveAjaxHandler();
-                var callback = function (data) {
-                    parseRpc(data, words);
-                    if (words.length >= maxRequest) {
-                        checkNow()
-                    }
-                };
-                var data = wordsToRPC(words, lang);
-                rpc(url, data, callback);
-            }
-
-            function wordsToRPC(words, lang) {
-                return '{"id":"c0","method":"spellcheck","params":{"lang":"' + lang + '","words":["' + words.join('","') + '"]}}'
-            }
-
-            function rpc(url, data, callback) {
-                var xhr = new XMLHttpRequest();
-                if (!xhr) {
-                    return null;
-                }
-                xhr.open('POST', url, true);
-                xhr.onreadystatechange = function () {
-                    if ((xhr.readyState == 4 && ((xhr.status >= 200 && xhr.status < 300) || xhr.status == 304 || xhr.status === 0 || xhr.status == 1223))) {
-
-                        callback(xhr.responseText);
-                        xhr = null;
-                    }
-                };
-                xhr.send(data);
-                return true;
-            }
-
-            function parseRpc(data, words) {
-                try {
-                    var json = JSON.parse(data);
-                } catch (e) {
-
-                    var msg = ("Nanospell need to be installed correctly before use (server:" + settings.server + ").\n\nPlease run nanospell/getstarted.html. ");
-
-                    if (window.location.href.indexOf('nanospell/') < 0) {
-                        console.log(msg)
-                    } else {
-                        if (confirm(msg)) {
-                            window.location = settings_path + "../getstarted.html"
-                        }
-                    }
-                }
-
-                var result = json.result;
-                for (var i in words) {
-                    var word = words[i];
-                    if (result[word]) {
-                        suggestionscache[word] = result[word];
-                        spellcache[word] = false;
-                    } else {
-                        spellcache[word] = true;
-                    }
-                }
-                render();
-            }
-
-            function resolveAjaxHandler() {
-                return '/spellcheck/nano/';
-            }
-
-            function render() {
-                var bookmarks = editor.getSelection().createBookmarks();
-                clearAllSpellCheckingSpans(editor.editable());
-                self.markAllTypos(editor);
-                editor.getSelection().selectBookmarks(bookmarks);
-
-                editor.fire('SpellcheckStart');
-                editor.nanospellstarted = true;
-            }
-
-            function clearAllSpellCheckingSpans(element) {
-                var spans = element.find('span.nanospell-typo');
-
-                for (var i = 0; i < spans.count(); i++) {
-                    var span = spans.getItem(i);
-                    unwrapTypoSpan(span);
-                }
-
-            }
-
-            function clearAllSpellCheckingSpansFromString(htmlString) {
-                var element = new CKEDITOR.dom.element('div');
-                element.setHtml(htmlString);
-                clearAllSpellCheckingSpans(element);
-                return element.getHtml();
-            }
-
-            function appendCustomStyles(path) {
-                CKEDITOR.document.appendStyleSheet(path + "/theme/nanospell.css");
-            }
-
-            var __memtok = null;
-            var __memtoks = null;
-
-            function wordTokenizer(singleton) {
-                if (!singleton && !!__memtok) {
-                    return __memtok
-                }
-                if (singleton && !!__memtoks) {
-                    return __memtoks
-                }
-                var email = "\\b[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}\\b";
-                var protocol = "\\bhttp[s]?://[a-z0-9#\\._/]{5,}\\b";
-                var domain = "\\bwww\.[a-z0-9#\._/]{8,128}[a-z0-9/]\\b";
-                var invalidchar = "\\s!\"#$%&()*+,-.â€¦/:;<=>?@[\\]^_{|}`\u200b\u00a7\u00a9\u00ab\u00ae\u00b1\u00b6\u00b7\u00b8\u00bb\u00bc\u00bd\u00be\u00bf\u00d7\u00f7\u00a4\u201d\u201c\u201e\u201f" + String.fromCharCode(160);
-                var validword = "[^" + invalidchar + "'\u2018\u2019][^" + invalidchar + "]+[^" + invalidchar + "'\u2018\u2019]";
-                var result = new RegExp("(" + email + ")|(" + protocol + ")|(" + domain + ")|(&#\d+;)|(" + validword + ")", singleton ? "" : "g");
-
-                if (singleton) {
-                    __memtoks = result
-                } else {
-                    __memtok = result
-                }
-                return result;
-            }
-
-            function getWords(corpus, max) {
-                var range = editor.createRange(),
-                    block,
-                    fullTextContext = '';
-
-                range.selectNodeContents(editor.editable());
-
-                var iterator = range.createIterator();
-                while (( block = iterator.getNextParagraph() )) {
-                    fullTextContext += block.getText() + ' ';
-                }
-
-                var matches = fullTextContext.match(wordTokenizer());
-                var uniqueWords = [];
-                var words = [];
-                if (!matches) {
-                    return words;
-                }
-                for (var i = 0; i < matches.length; i++) {
-                    var word = cleanQuotes(matches[i]);
-                    if (!uniqueWords[word] && validWordToken(word) && (typeof(spellcache[word]) === 'undefined')) {
-                        words.push(word);
-                        uniqueWords[word] = true;
-                        if (words.length >= max) {
-                            return words;
-                        }
-                    }
-                }
-                return words;
-            }
-
-            function cleanQuotes(word) {
-                return word.replace(/[\u2018\u2019]/g, "'");
-            }
-
-            var spellcache = [];
-            var suggestionscache = [];
-            var ignorecache = [];
-
-            function validWordToken(word) {
-                if (!word) {
-                    return false;
-                }
-                if (/\s/.test(word)) {
-                    return false;
-                }
-                if (/[:\.@\/\\]/.test(word)) {
-                    return false;
-                }
-                if (/^\d+$/.test(word) || word.length == 1) {
-                    return false;
-                }
-                var ingnoreAllCaps = (settings.ignore_block_caps === true);
-                var ignoreNumeric = (settings.ignore_non_alpha !== false);
-                if (ingnoreAllCaps && word.toUpperCase() == word) {
-                    return false;
-                }
-                if (ignoreNumeric && /\d/.test(word)) {
-                    return false;
-                }
-                if (ignorecache[word.toLowerCase()]) {
-                    return false;
-                }
-                return !hasPersonal(word);
-
-            }
-
-            function addPersonal(word) {
-                var value = localStorage.getItem('nano_spellchecker_personal');
-                if (value !== null && value !== "") {
-                    value += String.fromCharCode(127);
-                } else {
-                    value = "";
-                }
-                value += word.toLowerCase();
-                localStorage.setItem('nano_spellchecker_personal', value);
-            }
-
-            function hasPersonal(word) {
-                var value = localStorage.getItem('nano_spellchecker_personal');
-                if (value === null || value == "") {
-                    return false;
-                }
-                var records = value.split(String.fromCharCode(127));
-                word = word.toLowerCase();
-                for (var i = 0; i < records.length; i++) {
-                    if (records[i] === word) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-
-            function getSuggestions(word) {
-                word = cleanQuotes(word);
-                if (suggestionscache[word] && suggestionscache[word][0]) {
-                    if (suggestionscache[word][0].indexOf("*") == 0) {
-                        return ["nanospell\xA0plugin\xA0developer\xA0trial ", "ckeditor-spellcheck.nanospell.com/license\xA0"];
-                    }
-                }
-                return suggestionscache[word];
-            }
-
-            function wrapWithTypoSpan(range) {
-                var span = editor.document.createElement(
-                    'span',
-                    {
-                        attributes: {
-                            'class': 'nanospell-typo'
-                        }
-                    }
-                );
-
-                range.extractContents().appendTo(span);
-
-                range.insertNode(span);
-
-            }
-
-            function unwrapTypoSpan(span) {
-
-                span.remove(true);
-            }
-
-            function selectionCollapsed() {
-                if (!editor.getSelection()) {
-                    return true;
-                }
-                return editor.getSelection().getSelectedText().length == 0;
-            }
-
-            var spell_ticker = null;
-
-            function triggerSpelling(immediate) {
-                //only recheck when the user pauses typing
-                clearTimeout(spell_ticker);
-                if (selectionCollapsed) {
-                    spell_ticker = setTimeout(checkNow, immediate ? 50 : spell_delay);
-                }
-            }
-
-            function ignoreWord(target, word, all) {
-                var i;
-                if (all) {
-                    ignorecache[word.toLowerCase()] = true;
-                    for (i in suggestionscache) {
-                        if (i.toLowerCase() == word.toLowerCase()) {
-                            delete suggestionscache[i];
-                        }
-                    }
-                    var allInstances = editor.document.find('span.nanospell-typo');
-                    for (i = 0; i < allInstances.count(); i++) {
-                        var item = allInstances.getItem(i);
-                        var text = item.getText();
-                        if (text == word) {
-                            item.remove(true);
-                        }
-                    }
-                } else {
-                    target.remove(true);
-                }
-            }
-
-            function overrideCheckDirty() {
-
-                var editorCheckDirty = CKEDITOR.editor.prototype;
-
-                editorCheckDirty.checkDirty = CKEDITOR.tools.override(editorCheckDirty.checkDirty, function (org) {
-
-                    return function () {
-                        var retval = (this.status == 'ready');
-
-                        if (retval) {
-                            var currentData = clearAllSpellCheckingSpansFromString(this.getSnapshot()),
-                                prevData = clearAllSpellCheckingSpansFromString(this._.previousValue);
-
-                            retval = (retval && (prevData !== currentData))
-                        }
-
-                        return retval;
-                    };
-                });
-
-                editorCheckDirty.resetDirty = CKEDITOR.tools.override(editorCheckDirty.resetDirty, function (org) {
-                    return function () {
-                        this._.previousValue = clearAllSpellCheckingSpansFromString(this.getSnapshot());
-                    };
-                });
-            }
-
-
-        },
-        addRule: function (editor) {
-            var dataProcessor = editor.dataProcessor,
-                htmlFilter = dataProcessor && dataProcessor.htmlFilter,
-                pathFilters = editor._.elementsPath && editor._.elementsPath.filters,
-                dataFilter = dataProcessor && dataProcessor.dataFilter,
-                removeFormatFilter = editor.addRemoveFormatFilter,
-                pathFilter = function (element) {
-                    if (element.hasClass('nanospell-typo')) {
-                        return false;
-                    }
-                },
-                removeFormatFilterTemplate = function (element) {
-                    var result = true;
-
-                    if (element.hasClass('nanospell-typo')) {
-                        result = false;
-                    }
-
-                    return result;
-                };
-
-            if (pathFilters) {
-                pathFilters.push(pathFilter);
-            }
-
-            if (dataFilter) {
-                var dataFilterRules = {
-                    elements: {
-                        span: function (element) {
-
-                            var scaytState = element.hasClass('nanospell-typo');
-
-                            if (scaytState) {
-                                delete element.name;
-                            }
-
-                            return element;
-                        }
-                    }
-                };
-
-                dataFilter.addRules(dataFilterRules);
-            }
-
-            if (htmlFilter) {
-                var htmlFilterRules = {
-                    elements: {
-                        span: function (element) {
-
-                            var scaytState = element.hasClass('nanospell-typo');
-
-                            if (scaytState) {
-                                delete element.name;
-                            }
-
-                            return element;
-                        }
-                    }
-                };
-
-                htmlFilter.addRules(htmlFilterRules);
-            }
-
-            if (removeFormatFilter) {
-                removeFormatFilter.call(editor, removeFormatFilterTemplate);
-            }
-        },
-		markTypos: function(editor, node) {
+			this.addRule(editor);
+
+			overrideCheckDirty();
+
+			settings_path = this.path;
+			if (editor && !editor.config.nanospell) {
+				editor.config.nanospell = {};
+			}
+			this.settings = editor.config.nanospell;
+			if (!this.settings) {
+				this.settings = {};
+			}
+			lang = this.settings.dictionary || lang;
+			editor.addCommand('nanospell', {
+				exec: function (editor) {
+					if (!state) {
+						start();
+					} else {
+						stop();
+					}
+				},
+				editorFocus: true
+			});
+			editor.ui.addButton('nanospell', {
+				label: 'Spell Checking by Nanospell',
+				command: 'nanospell',
+				toolbar: 'nanospell',
+				icon: this.path + 'icons/nanospell.png'
+			});
+			editor.ui.addButton('Nanospell', {
+				label: 'Spell Checking by Nanospell',
+				command: 'nanospell',
+				toolbar: 'Nanospell',
+				icon: this.path + 'icons/nanospell.png'
+			});
+			editor.on("key", function (k) {
+				keyHandler(k.data.keyCode)
+			});
+			editor.on("focus", function () {
+				editorHasFocus = true;
+			});
+			editor.on("blur", function () {
+				editorHasFocus = false;
+			});
+			editor.on("instanceReady", function () {
+				if (this.settings.autostart !== false) {
+					start()
+				}
+			});
+			editor.on('mode', function () {
+				if (editor.mode == 'wysiwyg' && state) {
+					start()
+				}
+				return true;
+			});
+
+			setUpContextMenu(editor, this.path);
+
+
+			function setUpContextMenu(editor, path) {
+				var iconpath = path + 'icons/nanospell.png';
+				if (!editor.contextMenu) {
+					setTimeout(function () {
+						setUpContextMenu(editor, path)
+					}, 100);
+					return;
+				}
+				var generateSuggestionMenuItem = function (suggestion, icon, typo, element) {
+					return {
+						label: suggestion,
+						icon: icon ? iconpath : null,
+						group: 'nano',
+						onClick: function () {
+							if (suggestion.indexOf(String.fromCharCode(160)) > -1) {
+								return window.open('http://ckeditor-spellcheck.nanospell.com/license?discount=developer_max');
+							}
+
+							element.setText(suggestion);
+							// remove the wrapping span
+							element.remove(true);
+						}
+					}
+				};
+				var currentTypoText = function () {
+					var anchor = editor.getSelection().getStartElement();
+					var range = editor.createRange();
+					//Fixes FF and IE hilighting of selected word
+					range.selectNodeContents(anchor);
+					range.enlarge();
+					range.optimize();
+					range.select();
+					// end fix
+					return anchor.getText();
+				};
+
+				editor.addMenuGroup('nano', -10 * 3);
+				/*at the top*/
+				editor.addMenuGroup('nanotools', -10 * 3 + 1);
+				editor.contextMenu.addListener(function (element) {
+					if (!element.$ || !element.$.className || element.$.nodeName.toLowerCase() != 'span' || element.$.className !== "nanospell-typo") {
+						return;
+					}
+					var typo = currentTypoText();
+					var retobj = {};
+					var suggestions = getSuggestions(typo);
+					if (!suggestions) {
+						return;
+					}
+					if (suggestions.length == 0) {
+
+						editor.addMenuItem('nanopell_nosug', {
+							label: locale.nosuggestions,
+							icon: iconpath,
+							group: 'nano'
+						});
+						retobj["nanopell_nosug"] = CKEDITOR.TRISTATE_DISABLED
+					} else {
+						for (var i = 0; i < suggestions.length; i++) {
+							var word = suggestions[i];
+							if (word.replace(/^\s+|\s+$/g, '').length < 1) {
+								continue;
+							}
+							editor.addMenuItem('nanopell_sug_' + i, generateSuggestionMenuItem(word, !i, typo, element));
+							retobj["nanopell_sug_" + i] = CKEDITOR.TRISTATE_OFF;
+						}
+					}
+
+					editor.addMenuItem('nanopell_ignore', {
+						label: locale.ignore,
+						group: 'nanotools',
+						onClick: function () {
+							ignoreWord(element.$, typo, true);
+						}
+					});
+
+					retobj["nanopell_ignore"] = CKEDITOR.TRISTATE_OFF;
+					//
+					if (localStorage) {
+						editor.addMenuItem('nanopell_learn', {
+							label: locale.learn,
+							group: 'nanotools',
+							onClick: function () {
+								addPersonal(typo);
+								ignoreWord(element.$, typo, true);
+							}
+						});
+						retobj["nanopell_learn"] = CKEDITOR.TRISTATE_OFF;
+					}
+					return retobj
+				});
+
+				appendCustomStyles(settings_path);
+			}
+
+			/* #2 setup layer */
+			/* #3 nanospell util layer */
+			var start = function () {
+				editor.getCommand('nanospell').setState(CKEDITOR.TRISTATE_ON);
+				state = true;
+				var words = getWords(editor.document.$.body, maxRequest);
+				if (words.length == 0) {
+					render();
+				} else {
+					send(words);
+				}
+			};
+			var stop = function () {
+				editor.getCommand('nanospell').setState(CKEDITOR.TRISTATE_OFF);
+				state = false;
+				clearAllSpellCheckingSpans(editor.editable());
+			};
+
+			function checkNow() {
+				if (!selectionCollapsed()) {
+					return;
+				}
+				if (state) {
+					start();
+				}
+			}
+
+			function elementAtCursor() {
+				if (!editor.getSelection()) {
+					return null;
+				}
+				return editor.getSelection().getStartElement();
+			}
+
+			function keyHandler(ch8r) {
+				editorHasFocus = true;
+				//recheck after typing activity
+				if (ch8r >= 16 && ch8r <= 31) {
+					return;
+				}
+				if (ch8r >= 37 && ch8r <= 40) {
+					return;
+				}
+				var target = elementAtCursor();
+				if (!target) {
+					return;
+				}
+
+				var elementPath = new CKEDITOR.dom.elementPath(target);
+
+				//if! user is typing on a typo remove its underline
+
+				var spellCheckSpan = elementPath.contains(isSpellCheckSpan);
+
+				if (spellCheckSpan) {
+					var bookmarks = editor.getSelection().createBookmarks();
+					unwrapTypoSpan(spellCheckSpan);
+					editor.getSelection().selectBookmarks(bookmarks);
+				}
+
+				triggerSpelling((spell_fast_after_spacebar && (ch8r === 32 || ch8r === 10 || ch8r === 13)))
+			}
+
+			function isSpellCheckSpan(node) {
+				return node.getName() === 'span' && node.hasClass('nanospell-typo');
+			}
+
+			function send(words) {
+				var url = resolveAjaxHandler();
+				var callback = function (data) {
+					parseRpc(data, words);
+					if (words.length >= maxRequest) {
+						checkNow()
+					}
+				};
+				var data = wordsToRPC(words, lang);
+				rpc(url, data, callback);
+			}
+
+			function wordsToRPC(words, lang) {
+				return '{"id":"c0","method":"spellcheck","params":{"lang":"' + lang + '","words":["' + words.join('","') + '"]}}'
+			}
+
+			function rpc(url, data, callback) {
+				var xhr = new XMLHttpRequest();
+				if (!xhr) {
+					return null;
+				}
+				xhr.open('POST', url, true);
+				xhr.onreadystatechange = function () {
+					if ((xhr.readyState == 4 && ((xhr.status >= 200 && xhr.status < 300) || xhr.status == 304 || xhr.status === 0 || xhr.status == 1223))) {
+
+						callback(xhr.responseText);
+						xhr = null;
+					}
+				};
+				xhr.send(data);
+				return true;
+			}
+
+			function parseRpc(data, words) {
+				try {
+					var json = JSON.parse(data);
+				} catch (e) {
+
+					var msg = ("Nanospell need to be installed correctly before use (server:" + this.settings.server + ").\n\nPlease run nanospell/getstarted.html. ");
+
+					if (window.location.href.indexOf('nanospell/') < 0) {
+						console.log(msg)
+					} else {
+						if (confirm(msg)) {
+							window.location = settings_path + "../getstarted.html"
+						}
+					}
+				}
+
+				var result = json.result;
+				for (var i in words) {
+					var word = words[i];
+					if (result[word]) {
+						suggestionscache[word] = result[word];
+						spellcache[word] = false;
+					} else {
+						spellcache[word] = true;
+					}
+				}
+				render();
+			}
+
+			function resolveAjaxHandler() {
+				return '/spellcheck/nano/';
+			}
+
+			function render() {
+				var bookmarks = editor.getSelection().createBookmarks();
+				clearAllSpellCheckingSpans(editor.editable());
+				self.markAllTypos(editor);
+				editor.getSelection().selectBookmarks(bookmarks);
+
+				editor.fire('SpellcheckStart');
+				editor.nanospellstarted = true;
+			}
+
+			function clearAllSpellCheckingSpans(element) {
+				var spans = element.find('span.nanospell-typo');
+
+				for (var i = 0; i < spans.count(); i++) {
+					var span = spans.getItem(i);
+					unwrapTypoSpan(span);
+				}
+
+			}
+
+			function clearAllSpellCheckingSpansFromString(htmlString) {
+				var element = new CKEDITOR.dom.element('div');
+				element.setHtml(htmlString);
+				clearAllSpellCheckingSpans(element);
+				return element.getHtml();
+			}
+
+			function appendCustomStyles(path) {
+				CKEDITOR.document.appendStyleSheet(path + "/theme/nanospell.css");
+			}
+
+			var __memtok = null;
+			var __memtoks = null;
+
+			function wordTokenizer(singleton) {
+				if (!singleton && !!__memtok) {
+					return __memtok
+				}
+				if (singleton && !!__memtoks) {
+					return __memtoks
+				}
+				var email = "\\b[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}\\b";
+				var protocol = "\\bhttp[s]?://[a-z0-9#\\._/]{5,}\\b";
+				var domain = "\\bwww\.[a-z0-9#\._/]{8,128}[a-z0-9/]\\b";
+				var invalidchar = "\\s!\"#$%&()*+,-.â€¦/:;<=>?@[\\]^_{|}`\u200b\u00a7\u00a9\u00ab\u00ae\u00b1\u00b6\u00b7\u00b8\u00bb\u00bc\u00bd\u00be\u00bf\u00d7\u00f7\u00a4\u201d\u201c\u201e\u201f" + String.fromCharCode(160);
+				var validword = "[^" + invalidchar + "'\u2018\u2019][^" + invalidchar + "]+[^" + invalidchar + "'\u2018\u2019]";
+				var result = new RegExp("(" + email + ")|(" + protocol + ")|(" + domain + ")|(&#\d+;)|(" + validword + ")", singleton ? "" : "g");
+
+				if (singleton) {
+					__memtoks = result
+				} else {
+					__memtok = result
+				}
+				return result;
+			}
+
+			function getWords(corpus, max) {
+				var range = editor.createRange(),
+					block,
+					fullTextContext = '';
+
+				range.selectNodeContents(editor.editable());
+
+				var iterator = range.createIterator();
+				while (( block = iterator.getNextParagraph() )) {
+					fullTextContext += block.getText() + ' ';
+				}
+
+				var matches = fullTextContext.match(wordTokenizer());
+				var uniqueWords = [];
+				var words = [];
+				if (!matches) {
+					return words;
+				}
+				for (var i = 0; i < matches.length; i++) {
+					var word = cleanQuotes(matches[i]);
+					if (!uniqueWords[word] && validWordToken(word) && (typeof(spellcache[word]) === 'undefined')) {
+						words.push(word);
+						uniqueWords[word] = true;
+						if (words.length >= max) {
+							return words;
+						}
+					}
+				}
+				return words;
+			}
+
+			function cleanQuotes(word) {
+				return word.replace(/[\u2018\u2019]/g, "'");
+			}
+
+			var spellcache = [];
+			var suggestionscache = [];
+			var ignorecache = [];
+
+			function addPersonal(word) {
+				var value = localStorage.getItem('nano_spellchecker_personal');
+				if (value !== null && value !== "") {
+					value += String.fromCharCode(127);
+				} else {
+					value = "";
+				}
+				value += word.toLowerCase();
+				localStorage.setItem('nano_spellchecker_personal', value);
+			}
+
+			function getSuggestions(word) {
+				word = cleanQuotes(word);
+				if (suggestionscache[word] && suggestionscache[word][0]) {
+					if (suggestionscache[word][0].indexOf("*") == 0) {
+						return ["nanospell\xA0plugin\xA0developer\xA0trial ", "ckeditor-spellcheck.nanospell.com/license\xA0"];
+					}
+				}
+				return suggestionscache[word];
+			}
+
+			function wrapWithTypoSpan(range) {
+				var span = editor.document.createElement(
+					'span',
+					{
+						attributes: {
+							'class': 'nanospell-typo'
+						}
+					}
+				);
+
+				range.extractContents().appendTo(span);
+
+				range.insertNode(span);
+
+			}
+
+			function unwrapTypoSpan(span) {
+
+				span.remove(true);
+			}
+
+			function selectionCollapsed() {
+				if (!editor.getSelection()) {
+					return true;
+				}
+				return editor.getSelection().getSelectedText().length == 0;
+			}
+
+			var spell_ticker = null;
+
+			function triggerSpelling(immediate) {
+				//only recheck when the user pauses typing
+				clearTimeout(spell_ticker);
+				if (selectionCollapsed) {
+					spell_ticker = setTimeout(checkNow, immediate ? 50 : spell_delay);
+				}
+			}
+
+			function ignoreWord(target, word, all) {
+				var i;
+				if (all) {
+					ignorecache[word.toLowerCase()] = true;
+					for (i in suggestionscache) {
+						if (i.toLowerCase() == word.toLowerCase()) {
+							delete suggestionscache[i];
+						}
+					}
+					var allInstances = editor.document.find('span.nanospell-typo');
+					for (i = 0; i < allInstances.count(); i++) {
+						var item = allInstances.getItem(i);
+						var text = item.getText();
+						if (text == word) {
+							item.remove(true);
+						}
+					}
+				} else {
+					target.remove(true);
+				}
+			}
+
+			function overrideCheckDirty() {
+
+				var editorCheckDirty = CKEDITOR.editor.prototype;
+
+				editorCheckDirty.checkDirty = CKEDITOR.tools.override(editorCheckDirty.checkDirty, function (org) {
+
+					return function () {
+						var retval = (this.status == 'ready');
+
+						if (retval) {
+							var currentData = clearAllSpellCheckingSpansFromString(this.getSnapshot()),
+								prevData = clearAllSpellCheckingSpansFromString(this._.previousValue);
+
+							retval = (retval && (prevData !== currentData))
+						}
+
+						return retval;
+					};
+				});
+
+				editorCheckDirty.resetDirty = CKEDITOR.tools.override(editorCheckDirty.resetDirty, function (org) {
+					return function () {
+						this._.previousValue = clearAllSpellCheckingSpansFromString(this.getSnapshot());
+					};
+				});
+			}
+
+
+		},
+		addRule: function (editor) {
+			var dataProcessor = editor.dataProcessor,
+				htmlFilter = dataProcessor && dataProcessor.htmlFilter,
+				pathFilters = editor._.elementsPath && editor._.elementsPath.filters,
+				dataFilter = dataProcessor && dataProcessor.dataFilter,
+				removeFormatFilter = editor.addRemoveFormatFilter,
+				pathFilter = function (element) {
+					if (element.hasClass('nanospell-typo')) {
+						return false;
+					}
+				},
+				removeFormatFilterTemplate = function (element) {
+					var result = true;
+
+					if (element.hasClass('nanospell-typo')) {
+						result = false;
+					}
+
+					return result;
+				};
+
+			if (pathFilters) {
+				pathFilters.push(pathFilter);
+			}
+
+			if (dataFilter) {
+				var dataFilterRules = {
+					elements: {
+						span: function (element) {
+
+							var scaytState = element.hasClass('nanospell-typo');
+
+							if (scaytState) {
+								delete element.name;
+							}
+
+							return element;
+						}
+					}
+				};
+
+				dataFilter.addRules(dataFilterRules);
+			}
+
+			if (htmlFilter) {
+				var htmlFilterRules = {
+					elements: {
+						span: function (element) {
+
+							var scaytState = element.hasClass('nanospell-typo');
+
+							if (scaytState) {
+								delete element.name;
+							}
+
+							return element;
+						}
+					}
+				};
+
+				htmlFilter.addRules(htmlFilterRules);
+			}
+
+			if (removeFormatFilter) {
+				removeFormatFilter.call(editor, removeFormatFilterTemplate);
+			}
+		},
+		hasPersonal: function (word) {
+			var value = localStorage.getItem('nano_spellchecker_personal');
+			if (value === null || value == "") {
+				return false;
+			}
+			var records = value.split(String.fromCharCode(127));
+			word = word.toLowerCase();
+			for (var i = 0; i < records.length; i++) {
+				if (records[i] === word) {
+					return true;
+				}
+			}
+			return false;
+		},
+		validWordToken: function (word) {
+			if (!word) {
+				return false;
+			}
+			if (/\s/.test(word)) {
+				return false;
+			}
+			if (/[:\.@\/\\]/.test(word)) {
+				return false;
+			}
+			if (/^\d+$/.test(word) || word.length == 1) {
+				return false;
+			}
+			var ingnoreAllCaps = (this.settings.ignore_block_caps === true);
+			var ignoreNumeric = (this.settings.ignore_non_alpha !== false);
+			if (ingnoreAllCaps && word.toUpperCase() == word) {
+				return false;
+			}
+			if (ignoreNumeric && /\d/.test(word)) {
+				return false;
+			}
+			if (ignorecache[word.toLowerCase()]) {
+				return false;
+			}
+			return !this.hasPersonal(word);
+		},
+		markTypos: function (editor, node) {
 			var match;
 
 			var range = editor.createRange();
@@ -769,7 +768,7 @@
 			}
 
 		},
-		markAllTypos: function(editor) {
+		markAllTypos: function (editor) {
 			var range = editor.createRange(),
 				block;
 
@@ -781,6 +780,6 @@
 			}
 		},
 		WordWalker: WordWalker
-    });
+	});
 
 })();

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -24,7 +24,6 @@
 	var editorHasFocus = false;
 	var spellDelay = 250;
 	var spellFastAfterSpacebar = true;
-	var settingsPath;
 	var state = false;
 	var lang = "en";
 	var locale = {
@@ -156,10 +155,8 @@
 			var self = this;
 
 			this.addRule(editor);
-
 			overrideCheckDirty();
 
-			settingsPath = this.path;
 			if (editor && !editor.config.nanospell) {
 				editor.config.nanospell = {};
 			}
@@ -306,7 +303,7 @@
 					return retobj
 				});
 
-				appendCustomStyles(settingsPath);
+				appendCustomStyles(self.path);
 			}
 
 			/* #2 setup layer */
@@ -420,7 +417,7 @@
 						console.log(msg)
 					} else {
 						if (confirm(msg)) {
-							window.location = settingsPath + "../getstarted.html"
+							window.location = self.path + "../getstarted.html"
 						}
 					}
 				}

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -52,8 +52,6 @@
 		var startNode = range.startContainer;
 		var endNode = range.endContainer;
 
-		console.assert(startNode.equals(endNode));
-
 		function isRootBlockTextNode(node) {
 			// this function is an evaluator used to return only
 			// the text nodes in the walker.

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -32,6 +32,9 @@
 		learn: "Add To Personal Dictionary",
 		nosuggestions: "( No Spelling Suggestions )"
 	};
+	var spellcache = [];
+	var suggestionscache = [];
+	var ignorecache = [];
 
 	function cleanQuotes(word) {
 		return word.replace(/[\u2018\u2019]/g, "'");
@@ -137,10 +140,6 @@
 		icons: 'nanospell',
 		init: function (editor) {
 			var self = this;
-
-			this.spellcache = [];
-			this.suggestionscache = [];
-			this.ignorecache = [];
 
 			this.addRule(editor);
 
@@ -416,7 +415,7 @@
 				for (var i in words) {
 					var word = words[i];
 					if (result[word]) {
-						self.suggestionscache[word] = result[word];
+						suggestionscache[word] = result[word];
 						spellcache[word] = false;
 					} else {
 						spellcache[word] = true;
@@ -528,12 +527,12 @@
 
 			function getSuggestions(word) {
 				word = cleanQuotes(word);
-				if (self.suggestionscache[word] && self.suggestionscache[word][0]) {
+				if (suggestionscache[word] && suggestionscache[word][0]) {
 					if (suggestionscache[word][0].indexOf("*") == 0) {
 						return ["nanospell\xA0plugin\xA0developer\xA0trial ", "ckeditor-spellcheck.nanospell.com/license\xA0"];
 					}
 				}
-				return self.suggestionscache[word];
+				return suggestionscache[word];
 			}
 
 			function wrapWithTypoSpan(range) {
@@ -727,7 +726,7 @@
 			if (ignoreNumeric && /\d/.test(word)) {
 				return false;
 			}
-			if (this.ignorecache[word.toLowerCase()]) {
+			if (ignorecache[word.toLowerCase()]) {
 				return false;
 			}
 			return !this.hasPersonal(word);
@@ -749,7 +748,7 @@
 				if (!this.validWordToken(matchtext)) {
 					continue;
 				}
-				if (typeof(this.suggestionscache[cleanQuotes(matchtext)]) !== 'object') {
+				if (typeof(suggestionscache[cleanQuotes(matchtext)]) !== 'object') {
 					continue;
 				}
 				badRanges.push(match.range)

--- a/tests/smoke/ckeditor.html
+++ b/tests/smoke/ckeditor.html
@@ -1,9 +1,1 @@
 <textarea id="editor1" cols="80" rows="10"></textarea>
-<textarea name="editor2" cols="80" rows="10"></textarea>
-<textarea id="editor3" name="editor3" class="myclass" cols="80" rows="10"></textarea>
-<textarea name="editor4" class="myclass" cols="80" rows="10"></textarea>
-<textarea id="editor5" cols="80" rows="10"></textarea>
-<textarea id="editor6" cols="80" rows="10"></textarea>
-<textarea id="editor7" cols="80" rows="10"></textarea>
-<textarea id="editor8" cols="80" rows="10"></textarea>
-<textarea id="editor9" cols="80" rows="10"></textarea>

--- a/tests/smoke/ckeditor.js
+++ b/tests/smoke/ckeditor.js
@@ -1,4 +1,4 @@
-/* bender-tags: editor,unit */
+/* bender-tags: editor */
 /* bender-ckeditor-plugins: wysiwygarea,nanospell */
 
 // Clean up all instances been created on the page.
@@ -14,77 +14,8 @@ bender.test( {
 		removeAllInstances();
 	},
 
-	test_replaceId: function() {
+	'test it loads with the plugin enabled': function() {
 		CKEDITOR.replace( 'editor1' );
 		assert.isObject( CKEDITOR.instances.editor1, 'editor instance not found' );
-		assert.areSame( 'editor1', CKEDITOR.instances.editor1.name, 'instance name doesn\'t match' );
-		assert.areSame( document.getElementById( 'editor1' ), CKEDITOR.instances.editor1.element.$, 'instance element doesn\'t match' );
 	},
-
-	test_replaceName: function() {
-		CKEDITOR.replace( 'editor2' );
-		assert.isObject( CKEDITOR.instances.editor2, 'editor instance not found' );
-		assert.areSame( 'editor2', CKEDITOR.instances.editor2.name, 'instance name doesn\'t match' );
-		assert.areSame( document.getElementsByName( 'editor2' )[ 0 ], CKEDITOR.instances.editor2.element.$, 'instance element doesn\'t match' );
-	},
-
-	test_replaceElement: function() {
-		CKEDITOR.replace( document.getElementById( 'editor5' ) );
-		assert.isObject( CKEDITOR.instances.editor5, 'editor instance not found' );
-		assert.areSame( 'editor5', CKEDITOR.instances.editor5.name, 'instance name doesn\'t match' );
-		assert.areSame( document.getElementById( 'editor5' ), CKEDITOR.instances.editor5.element.$, 'instance element doesn\'t match' );
-	},
-
-
-	test_replaceError: function() {
-		assert.throwsError( Error, function() {
-			CKEDITOR.replace( 'error' );
-		} );
-	},
-
-	test_replaceAll_Class: function() {
-		CKEDITOR.replaceAll( 'myclass' );
-
-		assert.isObject( CKEDITOR.instances.editor3, 'editor3 instance not found' );
-		assert.areSame( 'editor3', CKEDITOR.instances.editor3.name, 'editor3 instance name doesn\'t match' );
-		assert.areSame( document.getElementById( 'editor3' ), CKEDITOR.instances.editor3.element.$, 'editor3 instance element doesn\'t match' );
-
-		assert.isObject( CKEDITOR.instances.editor4, 'editor4 instance not found' );
-		assert.areSame( 'editor4', CKEDITOR.instances.editor4.name, 'editor4 instance name doesn\'t match' );
-		assert.areSame( document.getElementsByName( 'editor4' )[ 0 ], CKEDITOR.instances.editor4.element.$, 'editor4 instance element doesn\'t match' );
-
-		assert.isUndefined( CKEDITOR.instances.editor6, 'editor6 should be undefined' );
-		assert.isUndefined( CKEDITOR.instances.editor7, 'editor7 should be undefined' );
-		assert.isUndefined( CKEDITOR.instances.editor8, 'editor8 should be undefined' );
-		assert.isUndefined( CKEDITOR.instances.editor8, 'editor9 should be undefined' );
-	},
-
-	test_replaceAll_Function: function() {
-		CKEDITOR.replaceAll( function( textarea ) {
-			return ( textarea.id != 'editor6' && textarea.id != 'editor8' );
-		} );
-
-		assert.isObject( CKEDITOR.instances.editor7, 'editor7 instance not found' );
-		assert.areSame( 'editor7', CKEDITOR.instances.editor7.name, 'editor7 instance name doesn\'t match' );
-		assert.areSame( document.getElementById( 'editor7' ), CKEDITOR.instances.editor7.element.$, 'editor7 instance element doesn\'t match' );
-
-		assert.isObject( CKEDITOR.instances.editor9, 'editor9 instance not found' );
-		assert.areSame( 'editor9', CKEDITOR.instances.editor9.name, 'editor9 instance name doesn\'t match' );
-		assert.areSame( document.getElementById( 'editor9' ), CKEDITOR.instances.editor9.element.$, 'editor9 instance element doesn\'t match' );
-
-		assert.isUndefined( CKEDITOR.instances.editor6, 'editor6 should be undefined' );
-		assert.isUndefined( CKEDITOR.instances.editor8, 'editor8 should be undefined' );
-	},
-
-	test_replaceAll: function() {
-		CKEDITOR.replaceAll();
-
-		assert.isObject( CKEDITOR.instances.editor6, 'editor6 instance not found' );
-		assert.areSame( 'editor6', CKEDITOR.instances.editor6.name, 'editor6 instance name doesn\'t match' );
-		assert.areSame( document.getElementById( 'editor6' ), CKEDITOR.instances.editor6.element.$, 'editor6 instance element doesn\'t match' );
-
-		assert.isObject( CKEDITOR.instances.editor8, 'editor8 editor instance not found' );
-		assert.areSame( 'editor8', CKEDITOR.instances.editor8.name, 'editor8 instance name doesn\'t match' );
-		assert.areSame( document.getElementById( 'editor8' ), CKEDITOR.instances.editor8.element.$, 'editor8 instance element doesn\'t match' );
-	}
 } );

--- a/tests/typowalking/markAllTypos.js
+++ b/tests/typowalking/markAllTypos.js
@@ -10,23 +10,28 @@ bender.editor = {
 };
 
 bender.test( {
-	getBlocksToBeMarked: function() {
+	setupSpy: function() {
 		var editor = this.editorBot.editor,
 			markTyposSpy;
 
-		markTyposSpy = sinon.spy(editor.plugins.nanospell.markTypos);
+		markTyposSpy = sinon.spy(editor.plugins.nanospell, 'markTypos');
 
-		editor.plugins.nanospell.markAllTypos(editor);
+		this.spy = markTyposSpy;
 
-		return markTyposSpy.args;
+		return markTyposSpy;
 	},
 
 	'test marking a simple paragraph': function() {
 		var bot = this.editorBot,
 			blocksToBeMarked;
+
+		this.setupSpy();
+
 		bot.setHtmlWithSelection( '<p>foo bar baz</p>' );
 
-		blocksToBeMarked = this.getBlocksToBeMarked();
+		bot.editor.plugins.nanospell.markAllTypos(bot.editor);
+
+		blocksToBeMarked = this.spy.args;
 
 		assert.areEqual('<p>foo bar baz</p>', blocksToBeMarked[0]);
 

--- a/tests/typowalking/markAllTypos.js
+++ b/tests/typowalking/markAllTypos.js
@@ -59,7 +59,13 @@ bender.test( {
 			blocksToBeMarked,
 			markedHtml;
 
-		bot.setHtmlWithSelection( '<ol><li>foo</li><li>bar</li><li>baz</li></ol>' );
+		bot.setHtmlWithSelection(
+			'<ol>' +
+				'<li>foo</li>' +
+				'<li>bar</li>' +
+				'<li>baz</li>' +
+			'</ol>'
+		);
 
 		bot.editor.plugins.nanospell.markAllTypos(bot.editor);
 
@@ -75,7 +81,15 @@ bender.test( {
 			blocksToBeMarked,
 			markedHtml;
 
-		bot.setHtmlWithSelection( '<ul><li><ol><li>foo bar baz</li></ol></li></ul>' );
+		bot.setHtmlWithSelection(
+			'<ul>' +
+				'<li>' +
+					'<ol>' +
+						'<li>foo bar baz</li>' +
+					'</ol>' +
+				'</li>' +
+			'</ul>'
+		);
 
 		bot.editor.plugins.nanospell.markAllTypos(bot.editor);
 
@@ -90,7 +104,16 @@ bender.test( {
 			blocksToBeMarked,
 			markedHtml;
 
-		bot.setHtmlWithSelection( '<ul><li><ol><li>foo</li><li>bar baz</li></ol></li></ul>' );
+		bot.setHtmlWithSelection(
+			'<ul>' +
+				'<li>' +
+					'<ol>' +
+						'<li>foo</li>' +
+						'<li>bar baz</li>' +
+					'</ol>' +
+				'</li>' +
+			'</ul>'
+		);
 
 		bot.editor.plugins.nanospell.markAllTypos(bot.editor);
 
@@ -105,13 +128,28 @@ bender.test( {
 			blocksToBeMarked,
 			markedHtml;
 
-		bot.setHtmlWithSelection( '<ul><li>fud<ol><li>foo</li><li>bar</li></ol>bop</li><li>baz</li></ul>' );
+		bot.setHtmlWithSelection(
+			'<ul>' +
+				'<li>fud' +
+					'<ol>' +
+						'<li>foo</li>' +
+						'<li>bar</li>' +
+					'</ol>' +
+				'bop</li>' +
+				'<li>baz</li>' +
+			'</ul>' );
 
 		bot.editor.plugins.nanospell.markAllTypos(bot.editor);
 
 		markedHtml = this.getMarkedHtmlBlocksAsText();
 
-		this.assertHtml('<li>fud<ol><li>foo</li><li>bar</li></ol>bop</li>', markedHtml[0]);
+		this.assertHtml(
+			'<li>fud' +
+				'<ol>' +
+					'<li>foo</li>' +
+					'<li>bar</li>' +
+				'</ol>' +
+			'bop</li>', markedHtml[0]);
 		this.assertHtml('<li>foo</li>', markedHtml[1]);
 		this.assertHtml('<li>bar</li>', markedHtml[2]);
 
@@ -120,7 +158,13 @@ bender.test( {
 		// so one of the blocks is marked with a range twice.
 		// this can be fixed later.
 
-		this.assertHtml('<li>fud<ol><li>foo</li><li>bar</li></ol>bop</li>', markedHtml[3]);
+		this.assertHtml(
+			'<li>fud' +
+				'<ol>' +
+					'<li>foo</li>' +
+					'<li>bar</li>' +
+				'</ol>' +
+			'bop</li>', markedHtml[3]);
 		this.assertHtml('<li>baz</li>', markedHtml[4]);
 	},
 

--- a/tests/typowalking/markAllTypos.js
+++ b/tests/typowalking/markAllTypos.js
@@ -23,20 +23,51 @@ bender.test( {
 
 		return markTyposSpy;
 	},
+	getMarkedHtmlBlocksAsText: function() {
+		var markTyposArgs = this.spy.args,
+			i,
+			markedHtml = [];
 
+		for (i = 0; i < markTyposArgs.length; i++) {
+			markedHtml.push(markTyposArgs[i][1].getOuterHtml());
+		}
+
+		return markedHtml;
+	},
+	setUp: function() {
+		this.setupSpy();
+	},
+	tearDown: function() {
+		this.editorBot.editor.plugins.nanospell.markTypos.restore();
+	},
 	'test marking a simple paragraph': function() {
 		var bot = this.editorBot,
-			blocksToBeMarked;
-
-		this.setupSpy();
+			blocksToBeMarked,
+			markedHtml;
 
 		bot.setHtmlWithSelection( '<p>foo bar baz</p>' );
 
 		bot.editor.plugins.nanospell.markAllTypos(bot.editor);
 
-		blocksToBeMarked = this.spy.args;
+		markedHtml = this.getMarkedHtmlBlocksAsText();
 
-		this.assertHtml('<p>foo bar baz</p>', blocksToBeMarked[0][1].getOuterHtml());
+		this.assertHtml('<p>foo bar baz</p>', markedHtml[0]);
+	},
+
+	'test marking a simple list': function() {
+		var bot = this.editorBot,
+			blocksToBeMarked,
+			markedHtml;
+
+		bot.setHtmlWithSelection( '<ol><li>foo</li><li>bar</li><li>baz</li></ol>' );
+
+		bot.editor.plugins.nanospell.markAllTypos(bot.editor);
+
+		markedHtml = this.getMarkedHtmlBlocksAsText();
+
+		this.assertHtml('<li>foo</li>', markedHtml[0]);
+		this.assertHtml('<li>bar</li>', markedHtml[1]);
+		this.assertHtml('<li>baz</li>', markedHtml[2]);
 	},
 
 

--- a/tests/typowalking/markAllTypos.js
+++ b/tests/typowalking/markAllTypos.js
@@ -1,0 +1,38 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: nanospell */
+
+'use strict';
+
+bender.editor = {
+	config: {
+		enterMode: CKEDITOR.ENTER_P
+	}
+};
+
+bender.test( {
+	getBlocksToBeMarked: function() {
+		var editor = this.editorBot.editor,
+			markTyposSpy;
+
+		markTyposSpy = sinon.spy(editor.plugins.nanospell.markTypos);
+
+		editor.plugins.nanospell.markAllTypos(editor);
+
+		return markTyposSpy.args;
+	},
+
+	'test marking a simple paragraph': function() {
+		var bot = this.editorBot,
+			blocksToBeMarked;
+		bot.setHtmlWithSelection( '<p>foo bar baz</p>' );
+
+		blocksToBeMarked = this.getBlocksToBeMarked();
+
+		assert.areEqual('<p>foo bar baz</p>', blocksToBeMarked[0]);
+
+
+	},
+
+
+} );
+

--- a/tests/typowalking/markAllTypos.js
+++ b/tests/typowalking/markAllTypos.js
@@ -10,6 +10,9 @@ bender.editor = {
 };
 
 bender.test( {
+	assertHtml: function( expected, actual, msg ) {
+		assert.areEqual( bender.tools.fixHtml( expected ), bender.tools.fixHtml( actual ), msg );
+	},
 	setupSpy: function() {
 		var editor = this.editorBot.editor,
 			markTyposSpy;
@@ -33,9 +36,7 @@ bender.test( {
 
 		blocksToBeMarked = this.spy.args;
 
-		assert.areEqual('<p>foo bar baz</p>', blocksToBeMarked[0]);
-
-
+		this.assertHtml('<p>foo bar baz</p>', blocksToBeMarked[0][1].getOuterHtml());
 	},
 
 

--- a/tests/typowalking/markAllTypos.js
+++ b/tests/typowalking/markAllTypos.js
@@ -105,16 +105,23 @@ bender.test( {
 			blocksToBeMarked,
 			markedHtml;
 
-		bot.setHtmlWithSelection( '<ul><li>fud<ol><li>foo</li><li>bar</li></ol></li><li>baz</li></ul>' );
+		bot.setHtmlWithSelection( '<ul><li>fud<ol><li>foo</li><li>bar</li></ol>bop</li><li>baz</li></ul>' );
 
 		bot.editor.plugins.nanospell.markAllTypos(bot.editor);
 
 		markedHtml = this.getMarkedHtmlBlocksAsText();
 
-		this.assertHtml('<li>fud<ol><li>foo</li><li>bar</li></ol></li><li>baz</li>', markedHtml[0]);
+		this.assertHtml('<li>fud<ol><li>foo</li><li>bar</li></ol>bop</li>', markedHtml[0]);
 		this.assertHtml('<li>foo</li>', markedHtml[1]);
 		this.assertHtml('<li>bar</li>', markedHtml[2]);
-		this.assertHtml('<li>baz</li>', markedHtml[3]);
+
+		// there is an odd case here (probably because CKEditor doesn't really support
+		// text following nested lists very well
+		// so one of the blocks is marked with a range twice.
+		// this can be fixed later.
+
+		this.assertHtml('<li>fud<ol><li>foo</li><li>bar</li></ol>bop</li>', markedHtml[3]);
+		this.assertHtml('<li>baz</li>', markedHtml[4]);
 	},
 
 

--- a/tests/typowalking/markAllTypos.js
+++ b/tests/typowalking/markAllTypos.js
@@ -70,6 +70,54 @@ bender.test( {
 		this.assertHtml('<li>baz</li>', markedHtml[2]);
 	},
 
+	'test marking a nested list': function() {
+		var bot = this.editorBot,
+			blocksToBeMarked,
+			markedHtml;
+
+		bot.setHtmlWithSelection( '<ul><li><ol><li>foo bar baz</li></ol></li></ul>' );
+
+		bot.editor.plugins.nanospell.markAllTypos(bot.editor);
+
+		markedHtml = this.getMarkedHtmlBlocksAsText();
+
+		this.assertHtml('<li>foo bar baz</li>', markedHtml[0]);
+	},
+
+
+	'test marking a nested multi item list': function() {
+		var bot = this.editorBot,
+			blocksToBeMarked,
+			markedHtml;
+
+		bot.setHtmlWithSelection( '<ul><li><ol><li>foo</li><li>bar baz</li></ol></li></ul>' );
+
+		bot.editor.plugins.nanospell.markAllTypos(bot.editor);
+
+		markedHtml = this.getMarkedHtmlBlocksAsText();
+
+		this.assertHtml('<li>foo</li>', markedHtml[0]);
+		this.assertHtml('<li>bar baz</li>', markedHtml[1]);
+	},
+
+	'test marking a complex nested list': function() {
+		var bot = this.editorBot,
+			blocksToBeMarked,
+			markedHtml;
+
+		bot.setHtmlWithSelection( '<ul><li>fud<ol><li>foo</li><li>bar</li></ol></li><li>baz</li></ul>' );
+
+		bot.editor.plugins.nanospell.markAllTypos(bot.editor);
+
+		markedHtml = this.getMarkedHtmlBlocksAsText();
+
+
+		this.assertHtml('<li>fud</li>', markedHtml[0]);
+		this.assertHtml('<li>foo</li>', markedHtml[1]);
+		this.assertHtml('<li>bar</li>', markedHtml[2]);
+		this.assertHtml('<li>baz</li>', markedHtml[3]);
+	},
+
 
 } );
 

--- a/tests/typowalking/markAllTypos.js
+++ b/tests/typowalking/markAllTypos.js
@@ -111,8 +111,7 @@ bender.test( {
 
 		markedHtml = this.getMarkedHtmlBlocksAsText();
 
-
-		this.assertHtml('<li>fud</li>', markedHtml[0]);
+		this.assertHtml('<li>fud<ol><li>foo</li><li>bar</li></ol></li><li>baz</li>', markedHtml[0]);
 		this.assertHtml('<li>foo</li>', markedHtml[1]);
 		this.assertHtml('<li>bar</li>', markedHtml[2]);
 		this.assertHtml('<li>baz</li>', markedHtml[3]);

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -56,7 +56,11 @@ bender.test( {
 	'test walking a single item list': function() {
 		var bot = this.editorBot,
 			wordsReturned;
-		bot.setHtmlWithSelection( '<ol><li>foo bar baz</li></ol>' );
+		bot.setHtmlWithSelection(
+			'<ol>' +
+				'<li>foo bar baz</li>' +
+			'</ol>'
+		);
 
 		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst().getFirst() );
 
@@ -67,7 +71,13 @@ bender.test( {
 		var bot = this.editorBot,
 			wordsReturned,
 			list;
-		bot.setHtmlWithSelection( '<ol><li>foo bar</li><li>bar baz</li><li>baz foo</li></ol>' );
+		bot.setHtmlWithSelection(
+			'<ol>' +
+				'<li>foo bar</li>' +
+				'<li>bar baz</li>' +
+				'<li>baz foo</li>' +
+			'</ol>'
+		);
 
 		list = this.editor.editable().getFirst();
 
@@ -81,7 +91,15 @@ bender.test( {
 			wordsReturned,
 			outerUnorderedList,
 			innerOrderedList;
-		bot.setHtmlWithSelection( '<ul><li><ol><li>foo bar baz</li></ol></li></ul>' );
+		bot.setHtmlWithSelection(
+			'<ul>' +
+				'<li>' +
+					'<ol>' +
+						'<li>foo bar baz</li>' +
+					'</ol>' +
+				'</li>' +
+			'</ul>'
+		);
 
 		outerUnorderedList = this.editor.editable().getFirst();
 
@@ -98,7 +116,14 @@ bender.test( {
 	'test walking across a double nested list': function() {
 		var bot = this.editorBot,
 			wordsReturned;
-		bot.setHtmlWithSelection( '<ul><li>foo<ol><li>bar baz</li></ol></li></ul>' );
+		bot.setHtmlWithSelection(
+			'<ul>' +
+				'<li>foo' +
+					'<ol>' +
+						'<li>bar baz</li>' +
+					'</ol>' +
+				'</li>' +
+			'</ul>' );
 
 		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst().getFirst() );
 
@@ -110,7 +135,15 @@ bender.test( {
 			wordsReturned,
 			outerUnorderedList,
 			innerOrderedList;
-		bot.setHtmlWithSelection( '<ul><li>foo<ol><li>bar</li></ol>baz</li></ul>' );
+		bot.setHtmlWithSelection(
+			'<ul>' +
+				'<li>foo' +
+					'<ol>' +
+						'<li>bar</li>' +
+					'</ol>' +
+				'baz</li>' +
+			'</ul>'
+		);
 
 		outerUnorderedList = this.editor.editable().getFirst();
 

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -10,7 +10,7 @@ bender.editor = {
 };
 
 bender.test( {
-	getWordsInEditor: function() {
+	getWordsInEditorWithWordWalker: function() {
 		var editor = this.editorBot.editor,
 			range,
 			wordwalker,
@@ -34,7 +34,7 @@ bender.test( {
 			wordsReturned;
 		bot.setHtmlWithSelection( '<p>foo bar baz</p>' );
 
-		wordsReturned = this.getWordsInEditor();
+		wordsReturned = this.getWordsInEditorWithWordWalker();
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
 	},
@@ -44,7 +44,7 @@ bender.test( {
 			wordsReturned;
 		bot.setHtmlWithSelection( '<p>f<i>o</i>o <strong>b</strong>ar <em>baz</em></p>' );
 
-		wordsReturned = this.getWordsInEditor();
+		wordsReturned = this.getWordsInEditorWithWordWalker();
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
 	},
@@ -54,7 +54,7 @@ bender.test( {
 			wordsReturned;
 		bot.setHtmlWithSelection( '<ol><li>foo bar baz</li></ol>' );
 
-		wordsReturned = this.getWordsInEditor();
+		wordsReturned = this.getWordsInEditorWithWordWalker();
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
 	},
@@ -64,7 +64,7 @@ bender.test( {
 			wordsReturned;
 		bot.setHtmlWithSelection( '<ol><li>foo</li><li>bar</li><li>baz</li></ol>' );
 
-		wordsReturned = this.getWordsInEditor();
+		wordsReturned = this.getWordsInEditorWithWordWalker();
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
 	},
@@ -74,7 +74,7 @@ bender.test( {
 			wordsReturned;
 		bot.setHtmlWithSelection( '<ul><li><ol><li>foo bar baz</li></ol></li></ul>' );
 
-		wordsReturned = this.getWordsInEditor();
+		wordsReturned = this.getWordsInEditorWithWordWalker();
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
 	},
@@ -84,7 +84,7 @@ bender.test( {
 			wordsReturned;
 		bot.setHtmlWithSelection( '<ul><li>foo<ol><li>bar baz</li></ol></li></ul>' );
 
-		wordsReturned = this.getWordsInEditor();
+		wordsReturned = this.getWordsInEditorWithWordWalker();
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
 	}

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -147,7 +147,7 @@ bender.test( {
 
 		outerUnorderedList = this.editor.editable().getFirst();
 
-		innerOrderedList = outerUnorderedList.getFirst().getFirst();
+		innerOrderedList = outerUnorderedList.getFirst().getChild(1);
 
 		// this is a bug!  but pinning it for later.
 		// although we have solved the problem of inner list being walked twice,

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -20,7 +20,7 @@ bender.test( {
 		range = new CKEDITOR.dom.range( editor.document );
 		range.selectNodeContents( editor.editable() );
 
-		wordwalker = new editor.plugins.nanospell.WordWalker(range);
+		wordwalker = new editor.plugins.nanospell.WordWalker(range, editor.editable().getFirst());
 
 		while (currWordObj = wordwalker.getNextWord()) {
 			wordsReturned.push(currWordObj.word);
@@ -86,7 +86,7 @@ bender.test( {
 
 		wordsReturned = this.getWordsInEditorWithWordWalker();
 
-		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
+		arrayAssert.itemsAreEqual(['foo'], wordsReturned);
 	}
 
 

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -10,7 +10,10 @@ bender.editor = {
 };
 
 bender.test( {
-	getWordsInEditorWithWordWalker: function() {
+	setUp: function() {
+		this.editor = this.editorBot.editor;
+	},
+	getWordsWithWordWalker: function(root) {
 		var editor = this.editorBot.editor,
 			range,
 			wordwalker,
@@ -19,7 +22,7 @@ bender.test( {
 
 		range = new CKEDITOR.dom.range( editor.document );
 		// assume there is only one block level element.
-		range.selectNodeContents( editor.editable().getFirst() );
+		range.selectNodeContents( root );
 
 		wordwalker = new editor.plugins.nanospell.WordWalker(range);
 
@@ -35,7 +38,7 @@ bender.test( {
 			wordsReturned;
 		bot.setHtmlWithSelection( '<p>foo bar baz</p>' );
 
-		wordsReturned = this.getWordsInEditorWithWordWalker();
+		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst() );
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
 	},
@@ -45,7 +48,7 @@ bender.test( {
 			wordsReturned;
 		bot.setHtmlWithSelection( '<p>f<i>o</i>o <strong>b</strong>ar <em>baz</em></p>' );
 
-		wordsReturned = this.getWordsInEditorWithWordWalker();
+		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst() );
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
 	},
@@ -55,7 +58,7 @@ bender.test( {
 			wordsReturned;
 		bot.setHtmlWithSelection( '<ol><li>foo bar baz</li></ol>' );
 
-		wordsReturned = this.getWordsInEditorWithWordWalker();
+		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst().getFirst() );
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
 	},
@@ -65,7 +68,7 @@ bender.test( {
 			wordsReturned;
 		bot.setHtmlWithSelection( '<ol><li>foo</li><li>bar</li><li>baz</li></ol>' );
 
-		wordsReturned = this.getWordsInEditorWithWordWalker();
+		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst().getFirst() );
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
 	},
@@ -75,7 +78,7 @@ bender.test( {
 			wordsReturned;
 		bot.setHtmlWithSelection( '<ul><li><ol><li>foo bar baz</li></ol></li></ul>' );
 
-		wordsReturned = this.getWordsInEditorWithWordWalker();
+		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst().getFirst() );
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
 	},
@@ -85,7 +88,7 @@ bender.test( {
 			wordsReturned;
 		bot.setHtmlWithSelection( '<ul><li>foo<ol><li>bar baz</li></ol></li></ul>' );
 
-		wordsReturned = this.getWordsInEditorWithWordWalker();
+		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst().getFirst() );
 
 		arrayAssert.itemsAreEqual(['foo'], wordsReturned);
 	}

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -18,9 +18,10 @@ bender.test( {
 			currWordObj;
 
 		range = new CKEDITOR.dom.range( editor.document );
-		range.selectNodeContents( editor.editable() );
+		// assume there is only one block level element.
+		range.selectNodeContents( editor.editable().getFirst() );
 
-		wordwalker = new editor.plugins.nanospell.WordWalker(range, editor.editable().getFirst());
+		wordwalker = new editor.plugins.nanospell.WordWalker(range);
 
 		while (currWordObj = wordwalker.getNextWord()) {
 			wordsReturned.push(currWordObj.word);

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -103,6 +103,25 @@ bender.test( {
 		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst().getFirst() );
 
 		arrayAssert.itemsAreEqual(['foo'], wordsReturned);
+	},
+
+	'test walking nested list wrapped with text nodes': function() {
+		var bot = this.editorBot,
+			wordsReturned,
+			outerUnorderedList,
+			innerOrderedList;
+		bot.setHtmlWithSelection( '<ul><li>foo<ol><li>bar</li></ol>baz</li></ul>' );
+
+		outerUnorderedList = this.editor.editable().getFirst();
+
+		innerOrderedList = outerUnorderedList.getFirst().getFirst();
+
+		// this is a bug!  but pinning it for later.
+		// although we have solved the problem of inner list being walked twice,
+		// it's not smart enough yet to realize we need to add a whitespace when skipping over.
+		// we need to detect this special case and add a whitespace (harder than it sounds)
+		arrayAssert.itemsAreEqual(['foobaz'], this.getWordsWithWordWalker( outerUnorderedList.getFirst() ));
+		arrayAssert.itemsAreEqual(['bar'], this.getWordsWithWordWalker( innerOrderedList.getFirst() ));
 	}
 
 

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -65,22 +65,34 @@ bender.test( {
 
 	'test walking multiple list items': function() {
 		var bot = this.editorBot,
-			wordsReturned;
-		bot.setHtmlWithSelection( '<ol><li>foo</li><li>bar</li><li>baz</li></ol>' );
+			wordsReturned,
+			list;
+		bot.setHtmlWithSelection( '<ol><li>foo bar</li><li>bar baz</li><li>baz foo</li></ol>' );
 
-		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst().getFirst() );
+		list = this.editor.editable().getFirst();
 
-		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
+		arrayAssert.itemsAreEqual(['foo', 'bar'], this.getWordsWithWordWalker( list.getChild(0) ));
+		arrayAssert.itemsAreEqual(['bar', 'baz'], this.getWordsWithWordWalker( list.getChild(1) ));
+		arrayAssert.itemsAreEqual(['baz', 'foo'], this.getWordsWithWordWalker( list.getChild(2) ));
 	},
 
 	'test walking in a double nested list': function() {
 		var bot = this.editorBot,
-			wordsReturned;
+			wordsReturned,
+			outerUnorderedList,
+			innerOrderedList;
 		bot.setHtmlWithSelection( '<ul><li><ol><li>foo bar baz</li></ol></li></ul>' );
 
-		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst().getFirst() );
+		outerUnorderedList = this.editor.editable().getFirst();
 
-		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
+		innerOrderedList = outerUnorderedList.getFirst().getFirst();
+
+		// due to the way that range iterators work, the `li` get passed in.
+
+		// we special-case the walker to not follow into nested blocks
+		// because of the special list case where they get passed in twice.
+		arrayAssert.itemsAreEqual([], this.getWordsWithWordWalker( outerUnorderedList.getFirst() ));
+		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], this.getWordsWithWordWalker( innerOrderedList.getFirst() ));
 	},
 
 	'test walking across a double nested list': function() {

--- a/tests/wordwalker/wordwalker.js
+++ b/tests/wordwalker/wordwalker.js
@@ -1,0 +1,30 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: nanospell */
+
+'use strict';
+
+bender.editor = {
+	config: {
+		enterMode: CKEDITOR.ENTER_P
+	},
+};
+
+bender.test( {
+	'test walking a simple sentence': function() {
+		var bot = this.editorBot,
+			editor = bot.editor,
+			range,
+			wordwalker;
+
+		bot.setHtmlWithSelection( '[<p>foo bar baz</p>]' );
+
+		range = new CKEDITOR.dom.range( editor.document );
+		range.selectNodeContents( editor.editable() );
+
+		wordwalker = new editor.plugins.nanospell.WordWalker(range);
+
+
+
+	},
+} );
+

--- a/tests/wordwalker/wordwalker.js
+++ b/tests/wordwalker/wordwalker.js
@@ -10,21 +10,85 @@ bender.editor = {
 };
 
 bender.test( {
-	'test walking a simple sentence': function() {
-		var bot = this.editorBot,
-			editor = bot.editor,
+	getWordsInEditor: function() {
+		var editor = this.editorBot.editor,
 			range,
-			wordwalker;
-
-		bot.setHtmlWithSelection( '[<p>foo bar baz</p>]' );
+			wordwalker,
+			wordsReturned = [],
+			currWordObj;
 
 		range = new CKEDITOR.dom.range( editor.document );
 		range.selectNodeContents( editor.editable() );
 
 		wordwalker = new editor.plugins.nanospell.WordWalker(range);
 
+		while (currWordObj = wordwalker.getNextWord()) {
+			wordsReturned.push(currWordObj.word);
+		}
 
-
+		return wordsReturned;
 	},
+
+	'test walking a simple paragraph': function() {
+		var bot = this.editorBot,
+			wordsReturned;
+		bot.setHtmlWithSelection( '<p>foo bar baz</p>' );
+
+		wordsReturned = this.getWordsInEditor();
+
+		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
+	},
+
+	'test walking a simple paragraph with inline formats': function() {
+		var bot = this.editorBot,
+			wordsReturned;
+		bot.setHtmlWithSelection( '<p>f<i>o</i>o <strong>b</strong>ar <em>baz</em></p>' );
+
+		wordsReturned = this.getWordsInEditor();
+
+		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
+	},
+
+	'test walking a single item list': function() {
+		var bot = this.editorBot,
+			wordsReturned;
+		bot.setHtmlWithSelection( '<ol><li>foo bar baz</li></ol>' );
+
+		wordsReturned = this.getWordsInEditor();
+
+		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
+	},
+
+	'test walking multiple list items': function() {
+		var bot = this.editorBot,
+			wordsReturned;
+		bot.setHtmlWithSelection( '<ol><li>foo</li><li>bar</li><li>baz</li></ol>' );
+
+		wordsReturned = this.getWordsInEditor();
+
+		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
+	},
+
+	'test walking in a double nested list': function() {
+		var bot = this.editorBot,
+			wordsReturned;
+		bot.setHtmlWithSelection( '<ul><li><ol><li>foo bar baz</li></ol></li></ul>' );
+
+		wordsReturned = this.getWordsInEditor();
+
+		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
+	},
+
+	'test walking across a double nested list': function() {
+		var bot = this.editorBot,
+			wordsReturned;
+		bot.setHtmlWithSelection( '<ul><li>foo<ol><li>bar baz</li></ol></li></ul>' );
+
+		wordsReturned = this.getWordsInEditor();
+
+		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
+	}
+
+
 } );
 


### PR DESCRIPTION
Broke this out as a self-PR for review / work separation purposes.  Ignore all the mess with dealing with node_modules and ckeditor paths for now.  

Nested list nodes get read twice - once as part of their parent list item, once again as single list items.  This appears to be due to some special casing inside CKEditor range iterators, although it probably makes sense for some previous case.  

https://github.com/ckeditor/ckeditor-dev/blob/12f0de314fd6fbee0bc4d35d541123d283fdecc9/core/dom/iterator.js#L324

```
                    // LIs are returned as is, with all their children (due to the
                    // nested lists). But, the next node is the node right after
                    // the current range, which could be an <li> child (nested
                    // lists) or the next sibling <li>.
```

I didn't perfectly break off all the test setup into here.  Some of it happened as part of moving my work over to this repo.  

This does NOT deal with the table content destruction issue I ran into (still haven't investigated) 
