### PR TITLE
Prevent concurrent spellcheck runs and list with text + table madness

### DIFF
--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -168,7 +168,7 @@
 			var self = this;
 
 			// a lock to prevent multiple spellchecks
-			this._isBusy = false;
+			this._spellCheckInProgress = false;
 
 			// store the current timer
 			this._timer = null;
@@ -341,12 +341,12 @@
 			}
 
 			function checkNow() {
-				if (!selectionCollapsed() || self._isBusy) {
+				if (!selectionCollapsed() || self._spellCheckInProgress) {
 					return;
 				}
 				if (state) {
 
-					self._isBusy = true;
+					self._spellCheckInProgress = true;
 
 					var words = getWords(editor.document.$.body, maxRequest);
 					if (words.length == 0) {
@@ -469,7 +469,7 @@
 
 				editor.fire('SpellcheckStart');
 				editor.nanospellstarted = true;
-				self._isBusy = false;
+				self._spellCheckInProgress = false;
 				self._timer = 0;
 			}
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -159,6 +159,12 @@
 		init: function (editor) {
 			var self = this;
 
+			// a lock to prevent multiple spellchecks
+			this._isBusy = false;
+
+			// store the current timer
+			this._timer = null;
+
 			this.addRule(editor);
 			overrideCheckDirty();
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -772,12 +772,9 @@
 		},
 		markTyposInRange: function (editor, range) {
 			var match;
-
 			var wordwalker = new this.WordWalker(range);
-
 			var badRanges = [];
 			var matchtext;
-
 
 			while ((match = wordwalker.getNextWord()) != null) {
 				matchtext = match.word;

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -70,7 +70,7 @@
 				( !node.isReadOnly() ) &&   // or read only
 				isNotBookmark(node) && // and isn't a fake bookmarking node
 				(path.blockLimit ? path.blockLimit.equals(startNode): true) &&
-				(path.block ? path.block.equals(startNode): true);
+				(path.block ? path.block.equals(startNode): true); // check we don't enter nested blocks (special list case)
 
 			return condition;
 		}

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -39,6 +39,7 @@
 		LF: 10,
 		CR: 13,
 	};
+	var DEFAULT_DELAY = 50;
 
 	function normalizeQuotes(word) {
 		return word.replace(/[\u2018\u2019]/g, "'");
@@ -331,7 +332,7 @@
 				editor.getCommand('nanospell').setState(CKEDITOR.TRISTATE_ON);
 				state = true;
 
-				startSpellCheckTimer(50);
+				startSpellCheckTimer(DEFAULT_DELAY);
 			}
 
 			function stop() {
@@ -593,7 +594,7 @@
 			function triggerSpelling(immediate) {
 				//only recheck when the user pauses typing
 				if (selectionCollapsed()) {
-					startSpellCheckTimer(immediate ? 50 : spellDelay)
+					startSpellCheckTimer(immediate ? DEFAULT_DELAY : spellDelay)
 				}
 			}
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -328,7 +328,7 @@
 				editor.getCommand('nanospell').setState(CKEDITOR.TRISTATE_ON);
 				state = true;
 
-				startTimer(50);
+				startSpellCheckTimer(50);
 			}
 
 			function stop() {
@@ -580,7 +580,7 @@
 				return editor.getSelection().getSelectedText().length == 0;
 			}
 
-			function startTimer(delay) {
+			function startSpellCheckTimer(delay) {
 				if (self._timer) {
 				} else {
 					self._timer = setTimeout(checkNow, delay);
@@ -590,7 +590,7 @@
 			function triggerSpelling(immediate) {
 				//only recheck when the user pauses typing
 				if (selectionCollapsed()) {
-					startTimer(immediate ? 50 : spellDelay)
+					startSpellCheckTimer(immediate ? 50 : spellDelay)
 				}
 			}
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -50,6 +50,7 @@
 		// and provides a mechanism for iterating over each word within,
 		// ignoring non-block elements.  (for example, span)
 		var isNotBookmark = CKEDITOR.dom.walker.bookmark(false, true);
+		var isBlockBoundary = CKEDITOR.dom.walker.blockBoundary();
 
 		var startNode = range.startContainer;
 		var endNode = range.endContainer;
@@ -61,17 +62,22 @@
 			// non-root block nodes must also be excluded.
 			// the text content of ckeditor bookmarks must also be excluded
 			// or &nbsp; will be added throughout.
-			var path = new CKEDITOR.dom.elementPath(node, startNode);
 
-			return node.type == CKEDITOR.NODE_TEXT && // it is a text node
+			var condition = node.type == CKEDITOR.NODE_TEXT && // it is a text node
 				node.getLength() > 0 &&  // and it's not empty
 				( !node.isReadOnly() ) &&   // or read only
-				isNotBookmark(node) &&  // and isn't a fake bookmarking node
-				(path.block && path.block.equals(startNode)); // it's not nested in a deeper block from our root.
+				isNotBookmark(node);// and isn't a fake bookmarking node
+
+			return condition;
+		}
+
+		function guard(node) {
+			return isBlockBoundary(node) && !(node.equals(startNode));
 		}
 
 		this.rootBlockTextNodeWalker = new CKEDITOR.dom.walker(range);
 		this.rootBlockTextNodeWalker.evaluator = isRootBlockTextNode;
+		this.rootBlockTextNodeWalker.guard = guard;
 
 		var wordSeparatorRegex = /[.,"'?!;: \u0085\u00a0\u1680\u280e\u2028\u2029\u202f\u205f\u3000]/;
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -471,7 +471,7 @@
 				editor.fire('SpellcheckStart');
 				editor.nanospellstarted = true;
 				self._spellCheckInProgress = false;
-				self._timer = 0;
+				self._timer = null;
 			}
 
 			function clearAllSpellCheckingSpans(element) {
@@ -585,7 +585,7 @@
 			}
 
 			function startSpellCheckTimer(delay) {
-				if (self._timer) {
+				if (self._timer === null) {
 				} else {
 					self._timer = setTimeout(checkNow, delay);
 				}

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -585,7 +585,7 @@
 			}
 
 			function startSpellCheckTimer(delay) {
-				if (self._timer === null) {
+				if (self._timer !== null) {
 				} else {
 					self._timer = setTimeout(checkNow, delay);
 				}

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -766,10 +766,14 @@
 			range.insertNode(span);
 		},
 		markTypos: function (editor, node) {
-			var match;
-
 			var range = editor.createRange();
 			range.selectNodeContents(node);
+
+			this.markTyposInRange(range);
+		},
+		markTyposInRange: function (editor, range) {
+			var match;
+
 			var wordwalker = new this.WordWalker(range);
 
 			var badRanges = [];
@@ -795,7 +799,6 @@
 			while (currRange = rangeListIterator.getNextRange()) {
 				this.wrapWithTypoSpan(editor, currRange);
 			}
-
 		},
 		markAllTypos: function (editor) {
 			var range = editor.createRange(),

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -69,8 +69,8 @@
 				node.getLength() > 0 &&  // and it's not empty
 				( !node.isReadOnly() ) &&   // or read only
 				isNotBookmark(node) && // and isn't a fake bookmarking node
-				(path.blockLimit ? path.blockLimit.equals(startNode): true) &&
-				(path.block ? path.block.equals(startNode): true); // check we don't enter nested blocks (special list case)
+				(path.blockLimit ? path.blockLimit.equals(startNode): true) && // check we don't enter another block-like element
+				(path.block ? path.block.equals(startNode): true); // check we don't enter nested blocks (special list case since it's not considered a limit)
 
 			return condition;
 		}

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -63,10 +63,14 @@
 			// the text content of ckeditor bookmarks must also be excluded
 			// or &nbsp; will be added throughout.
 
+			var path = new CKEDITOR.dom.elementPath(node, startNode);
+
 			var condition = node.type == CKEDITOR.NODE_TEXT && // it is a text node
 				node.getLength() > 0 &&  // and it's not empty
 				( !node.isReadOnly() ) &&   // or read only
-				isNotBookmark(node);// and isn't a fake bookmarking node
+				isNotBookmark(node) && // and isn't a fake bookmarking node
+				(path.blockLimit ? path.blockLimit.equals(startNode): true) &&
+				(path.block ? path.block.equals(startNode): true);
 
 			return condition;
 		}
@@ -77,7 +81,7 @@
 
 		this.rootBlockTextNodeWalker = new CKEDITOR.dom.walker(range);
 		this.rootBlockTextNodeWalker.evaluator = isRootBlockTextNode;
-		this.rootBlockTextNodeWalker.guard = guard;
+		//this.rootBlockTextNodeWalker.guard = guard;
 
 		var wordSeparatorRegex = /[.,"'?!;: \u0085\u00a0\u1680\u280e\u2028\u2029\u202f\u205f\u3000]/;
 
@@ -769,7 +773,7 @@
 			var range = editor.createRange();
 			range.selectNodeContents(node);
 
-			this.markTyposInRange(range);
+			this.markTyposInRange(editor, range);
 		},
 		markTyposInRange: function (editor, range) {
 			var match;

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -75,13 +75,8 @@
 			return condition;
 		}
 
-		function guard(node) {
-			return isBlockBoundary(node) && !(node.equals(startNode));
-		}
-
 		this.rootBlockTextNodeWalker = new CKEDITOR.dom.walker(range);
 		this.rootBlockTextNodeWalker.evaluator = isRootBlockTextNode;
-		//this.rootBlockTextNodeWalker.guard = guard;
 
 		var wordSeparatorRegex = /[.,"'?!;: \u0085\u00a0\u1680\u280e\u2028\u2029\u202f\u205f\u3000]/;
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -24,7 +24,7 @@
 	var editorHasFocus = false;
 	var spellDelay = 250;
 	var spellFastAfterSpacebar = true;
-	var state = false;
+	var commandIsActive = false;
 	var lang = "en";
 	var locale = {
 		ignore: "Ignore",
@@ -187,7 +187,7 @@
 			lang = this.settings.dictionary || lang;
 			editor.addCommand('nanospell', {
 				exec: function (editor) {
-					if (!state) {
+					if (!commandIsActive) {
 						start();
 					} else {
 						stop();
@@ -222,7 +222,7 @@
 				}
 			});
 			editor.on('mode', function () {
-				if (editor.mode == 'wysiwyg' && state) {
+				if (editor.mode == 'wysiwyg' && commandIsActive) {
 					start()
 				}
 				return true;
@@ -330,14 +330,14 @@
 			/* #3 nanospell util layer */
 			function start() {
 				editor.getCommand('nanospell').setState(CKEDITOR.TRISTATE_ON);
-				state = true;
+				commandIsActive = true;
 
 				startSpellCheckTimer(DEFAULT_DELAY);
 			}
 
 			function stop() {
 				editor.getCommand('nanospell').setState(CKEDITOR.TRISTATE_OFF);
-				state = false;
+				commandIsActive = false;
 				clearAllSpellCheckingSpans(editor.editable());
 			}
 
@@ -345,7 +345,7 @@
 				if (!selectionCollapsed() || self._spellCheckInProgress) {
 					return;
 				}
-				if (state) {
+				if (commandIsActive) {
 
 					self._spellCheckInProgress = true;
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -69,6 +69,9 @@
 				node.getLength() > 0 &&  // and it's not empty
 				( !node.isReadOnly() ) &&   // or read only
 				isNotBookmark(node) && // and isn't a fake bookmarking node
+				// tables and list items can get a bit weird with getNextParagraph()
+				// for example causing list item descendants to be included as part of the original list item
+				// and also individually as their own paragraph-like elements
 				(path.blockLimit ? path.blockLimit.equals(startNode): true) && // check we don't enter another block-like element
 				(path.block ? path.block.equals(startNode): true); // check we don't enter nested blocks (special list case since it's not considered a limit)
 

--- a/tests/typowalking/markAllTypos.js
+++ b/tests/typowalking/markAllTypos.js
@@ -166,8 +166,7 @@ bender.test( {
 				'</ol>' +
 			'bop</li>', markedHtml[3]);
 		this.assertHtml('<li>baz</li>', markedHtml[4]);
-	},
-
+	}
 
 } );
 

--- a/tests/typowalking/markAllTyposTables.js
+++ b/tests/typowalking/markAllTyposTables.js
@@ -97,11 +97,7 @@ bender.test( {
 		this.assertHtml('<p>cell2</p>', markedHtml[1]);
 		this.assertHtml('<td>ce<em>l</em>l3</td>', markedHtml[2]);
 		this.assertHtml('<td>cell4</td>', markedHtml[3]);
-	},
-
-
-
-
+	}
 
 } );
 

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -153,9 +153,41 @@ bender.test( {
 		// although we have solved the problem of inner list being walked twice,
 		// it's not smart enough yet to realize we need to add a whitespace when skipping over.
 		// we need to detect this special case and add a whitespace (harder than it sounds)
-		arrayAssert.itemsAreEqual(['foobaz'], this.getWordsWithWordWalker( outerUnorderedList.getFirst() ));
+		arrayAssert.itemsAreEqual(['foo'], this.getWordsWithWordWalker( outerUnorderedList.getFirst() ));
 		arrayAssert.itemsAreEqual(['bar'], this.getWordsWithWordWalker( innerOrderedList.getFirst() ));
+	},
+
+	'test walking nested table in list': function() {
+		var bot = this.editorBot,
+			wordsReturned,
+			outerUnorderedList,
+			innerOrderedList;
+		bot.setHtmlWithSelection(
+			'<ul><li>' +
+				'asdf' +
+			'<table>' +
+			'<thead>' +
+			'<tr>' +
+			'<th>cell1</th>' +
+			'<th>cell2</th>' +
+			'</tr>' +
+			'</thead>' +
+			'<tbody>' +
+			'<tr>' +
+			'<td>cell3</td>' +
+			'<td>cell4</td>' +
+			'</tr>' +
+			'</tbody>' +
+			'</table>' +
+			'</li></ul>'
+		);
+
+
+		outerUnorderedList = this.editor.editable().getFirst();
+
+		arrayAssert.itemsAreEqual(['asdf'], this.getWordsWithWordWalker( outerUnorderedList.getFirst() ));
 	}
+
 
 
 } );

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -182,13 +182,9 @@ bender.test( {
 			'</li></ul>'
 		);
 
-
 		outerUnorderedList = this.editor.editable().getFirst();
 
 		arrayAssert.itemsAreEqual(['asdf'], this.getWordsWithWordWalker( outerUnorderedList.getFirst() ));
 	}
-
-
-
 } );
 

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -153,7 +153,7 @@ bender.test( {
 		// although we have solved the problem of inner list being walked twice,
 		// it's not smart enough yet to realize we need to add a whitespace when skipping over.
 		// we need to detect this special case and add a whitespace (harder than it sounds)
-		arrayAssert.itemsAreEqual(['foo'], this.getWordsWithWordWalker( outerUnorderedList.getFirst() ));
+		arrayAssert.itemsAreEqual(['foo', 'baz'], this.getWordsWithWordWalker( outerUnorderedList.getFirst() ));
 		arrayAssert.itemsAreEqual(['bar'], this.getWordsWithWordWalker( innerOrderedList.getFirst() ));
 	},
 

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -157,7 +157,7 @@ bender.test( {
 		arrayAssert.itemsAreEqual(['bar'], this.getWordsWithWordWalker( innerOrderedList.getFirst() ));
 	},
 
-	'test walking nested table in list': function() {
+	'test walking list item which has textnode with table sibling': function() {
 		var bot = this.editorBot,
 			wordsReturned,
 			outerUnorderedList,
@@ -165,20 +165,20 @@ bender.test( {
 		bot.setHtmlWithSelection(
 			'<ul><li>' +
 				'asdf' +
-			'<table>' +
-			'<thead>' +
-			'<tr>' +
-			'<th>cell1</th>' +
-			'<th>cell2</th>' +
-			'</tr>' +
-			'</thead>' +
-			'<tbody>' +
-			'<tr>' +
-			'<td>cell3</td>' +
-			'<td>cell4</td>' +
-			'</tr>' +
-			'</tbody>' +
-			'</table>' +
+				'<table>' +
+					'<thead>' +
+						'<tr>' +
+							'<th>cell1</th>' +
+							'<th>cell2</th>' +
+						'</tr>' +
+					'</thead>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>cell3</td>' +
+							'<td>cell4</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
 			'</li></ul>'
 		);
 


### PR DESCRIPTION
This actually prevents two issues:
- concurrent spellcheck runs (hard to test, but long running spellcheck causes multiple spellchecks to run at the same time and destroy each other)
- list item with text followed by a table causes walker to misbehave and include the table cells when walking the list item.  
