### PR TITLE
Hook spellcheck flow up to CKEditor events

### DIFF
--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -357,7 +357,7 @@
 
 					self._spellCheckInProgress = true;
 
-					var words = getAllWords(maxRequest);
+					var words = getAllWords();
 					if (words.length == 0) {
 						render();
 					} else {
@@ -528,7 +528,7 @@
 				return result;
 			}
 
-			function getWords(corpus, max) {
+			function getWordsInCorpus(corpus) {
 				var matches = corpus.match(wordTokenizer());
 				var uniqueWords = [];
 				var words = [];
@@ -540,27 +540,31 @@
 					if (!uniqueWords[word] && self.validWordToken(word) && (typeof(spellcache[word]) === 'undefined')) {
 						words.push(word);
 						uniqueWords[word] = true;
-						if (words.length >= max) {
-							return words;
-						}
+						//if (words.length >= max) {
+						//	return words;
+						//}
 					}
 				}
 				return words;
 			}
 
-			function getAllWords(max) {
-				var range = editor.createRange(),
-					block,
+			function getWordsInRange(range) {
+				var block,
 					fullTextContext = '';
-
-				range.selectNodeContents(editor.editable());
-
 				var iterator = range.createIterator();
 				while (( block = iterator.getNextParagraph() )) {
 					fullTextContext += block.getText() + ' ';
 				}
 
-				return getWords(fullTextContent, max);
+				return getWordsInCorpus(fullTextContent, max);
+			}
+
+			function getAllWords() {
+				var range = editor.createRange();
+
+				range.selectNodeContents(editor.editable());
+
+				return getWordsInRange(range);
 			}
 
 			function addPersonal(word) {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -569,7 +569,7 @@
 					fullTextContext += block.getText() + ' ';
 				}
 
-				return getWordsInCorpus(fullTextContent, max);
+				return getWordsInCorpus(fullTextContext);
 			}
 
 			function getAllWords() {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -475,9 +475,7 @@
 				clearAllSpellCheckingSpans(editor.editable());
 				self.markAllTypos(editor);
 				editor.getSelection().selectBookmarks(bookmarks);
-
-				editor.fire('SpellcheckStart');
-				editor.nanospellstarted = true;
+				
 				self._spellCheckInProgress = false;
 				self._timer = null;
 			}

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -42,6 +42,7 @@
 	var DEFAULT_DELAY = 50;
 	var EVENT_NAMES = {
 		START_SPELLCHECK_ON: 'startSpellCheckOn',
+		START_SCAN_ALL_WORDS: 'startScanAllWords',
 		START_SCAN_WORDS: 'startScanWords',
 		START_CHECK_WORDS: 'startCheckWordsAjax',
 		START_MARK_TYPOS: 'startMarkTypos'
@@ -463,7 +464,6 @@
 						spellcache[word] = true;
 					}
 				}
-				render();
 			}
 
 			function resolveAjaxHandler() {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -40,6 +40,12 @@
 		CR: 13,
 	};
 	var DEFAULT_DELAY = 50;
+	var EVENT_NAMES = {
+		START_SPELLCHECK_ON: 'startSpellCheckOn',
+		START_SCAN_WORDS: 'startScanWords',
+		START_CHECK_WORDS: 'startCheckWordsAjax',
+		START_MARK_TYPOS: 'startMarkTypos'
+	};
 
 	function normalizeQuotes(word) {
 		return word.replace(/[\u2018\u2019]/g, "'");

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -77,11 +77,11 @@
 				node.getLength() > 0 &&  // and it's not empty
 				( !node.isReadOnly() ) &&   // or read only
 				isNotBookmark(node) && // and isn't a fake bookmarking node
-				// tables and list items can get a bit weird with getNextParagraph()
-				// for example causing list item descendants to be included as part of the original list item
-				// and also individually as their own paragraph-like elements
-				(path.blockLimit ? path.blockLimit.equals(startNode): true) && // check we don't enter another block-like element
-				(path.block ? path.block.equals(startNode): true); // check we don't enter nested blocks (special list case since it's not considered a limit)
+					// tables and list items can get a bit weird with getNextParagraph()
+					// for example causing list item descendants to be included as part of the original list item
+					// and also individually as their own paragraph-like elements
+				(path.blockLimit ? path.blockLimit.equals(startNode) : true) && // check we don't enter another block-like element
+				(path.block ? path.block.equals(startNode) : true); // check we don't enter nested blocks (special list case since it's not considered a limit)
 
 			return condition;
 		}
@@ -544,7 +544,7 @@
 			}
 
 			/*
-			Given some text, get the unique words in it that we don't have a spellcheck status for
+			 Given some text, get the unique words in it that we don't have a spellcheck status for
 			 */
 			function getWordsInCorpus(corpus) {
 				var matches = corpus.match(wordTokenizer());
@@ -567,7 +567,7 @@
 			}
 
 			/*
-			for a given range, get the unique words in it that we don't have a spellcheck status for
+			 for a given range, get the unique words in it that we don't have a spellcheck status for
 			 */
 			function getWordsInRange(range) {
 				var block,
@@ -581,7 +581,7 @@
 			}
 
 			/*
-			for the entire document, get the unique words in it that we don't have a spellcheck status for
+			 for the entire document, get the unique words in it that we don't have a spellcheck status for
 			 */
 			function getAllWords() {
 				var range = editor.createRange();

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -44,7 +44,8 @@
 		START_SPELLCHECK_ON: 'startSpellCheckOn',
 		START_SCAN_WORDS: 'startScanWords',
 		START_CHECK_WORDS: 'startCheckWordsAjax',
-		START_MARK_TYPOS: 'startMarkTypos'
+		START_MARK_TYPOS: 'startMarkTypos',
+		SPELLCHECK_COMPLETE: 'spellCheckComplete'
 	};
 
 	function normalizeQuotes(word) {
@@ -491,6 +492,7 @@
 
 				self._spellCheckInProgress = false;
 				self._timer = null;
+				editor.fire(EVENT_NAMES.SPELLCHECK_COMPLETE);
 			}
 
 			editor.on(EVENT_NAMES.START_MARK_TYPOS, render, self);

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -543,6 +543,9 @@
 				return result;
 			}
 
+			/*
+			Given some text, get the unique words in it that we don't have a spellcheck status for
+			 */
 			function getWordsInCorpus(corpus) {
 				var matches = corpus.match(wordTokenizer());
 				var uniqueWords = [];
@@ -563,6 +566,9 @@
 				return words;
 			}
 
+			/*
+			for a given range, get the unique words in it that we don't have a spellcheck status for
+			 */
 			function getWordsInRange(range) {
 				var block,
 					fullTextContext = '';
@@ -574,6 +580,9 @@
 				return getWordsInCorpus(fullTextContext);
 			}
 
+			/*
+			for the entire document, get the unique words in it that we don't have a spellcheck status for
+			 */
 			function getAllWords() {
 				var range = editor.createRange();
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -73,13 +73,15 @@
 
 			var path = new CKEDITOR.dom.elementPath(node, startNode);
 
+			// tables and list items can get a bit weird with getNextParagraph()
+			// for example causing list item descendants to be included as part of the original list item
+			// and also individually as their own paragraph-like elements
+			// hence why the below condition is a bit complicated.
+
 			var condition = node.type == CKEDITOR.NODE_TEXT && // it is a text node
 				node.getLength() > 0 &&  // and it's not empty
 				( !node.isReadOnly() ) &&   // or read only
 				isNotBookmark(node) && // and isn't a fake bookmarking node
-					// tables and list items can get a bit weird with getNextParagraph()
-					// for example causing list item descendants to be included as part of the original list item
-					// and also individually as their own paragraph-like elements
 				(path.blockLimit ? path.blockLimit.equals(startNode) : true) && // check we don't enter another block-like element
 				(path.block ? path.block.equals(startNode) : true); // check we don't enter nested blocks (special list case since it's not considered a limit)
 
@@ -558,9 +560,6 @@
 					if (!uniqueWords[word] && self.validWordToken(word) && (typeof(spellcache[word]) === 'undefined')) {
 						words.push(word);
 						uniqueWords[word] = true;
-						//if (words.length >= max) {
-						//	return words;
-						//}
 					}
 				}
 				return words;

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -343,6 +343,8 @@
 
 			function checkNow() {
 				if (!selectionCollapsed() || self._spellCheckInProgress) {
+					self._timer = null;
+					startSpellCheckTimer(DEFAULT_DELAY);
 					return;
 				}
 				if (commandIsActive) {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -357,7 +357,7 @@
 
 					self._spellCheckInProgress = true;
 
-					var words = getWords(editor.document.$.body, maxRequest);
+					var words = getAllWords(maxRequest);
 					if (words.length == 0) {
 						render();
 					} else {
@@ -529,18 +529,7 @@
 			}
 
 			function getWords(corpus, max) {
-				var range = editor.createRange(),
-					block,
-					fullTextContext = '';
-
-				range.selectNodeContents(editor.editable());
-
-				var iterator = range.createIterator();
-				while (( block = iterator.getNextParagraph() )) {
-					fullTextContext += block.getText() + ' ';
-				}
-
-				var matches = fullTextContext.match(wordTokenizer());
+				var matches = corpus.match(wordTokenizer());
 				var uniqueWords = [];
 				var words = [];
 				if (!matches) {
@@ -557,6 +546,21 @@
 					}
 				}
 				return words;
+			}
+
+			function getAllWords(max) {
+				var range = editor.createRange(),
+					block,
+					fullTextContext = '';
+
+				range.selectNodeContents(editor.editable());
+
+				var iterator = range.createIterator();
+				while (( block = iterator.getNextParagraph() )) {
+					fullTextContext += block.getText() + ' ';
+				}
+
+				return getWords(fullTextContent, max);
 			}
 
 			function addPersonal(word) {
@@ -581,7 +585,6 @@
 			}
 
 			function unwrapTypoSpan(span) {
-
 				span.remove(true);
 			}
 

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-(function() {
+(function () {
 	bender.editor = {
 		config: {
 			enterMode: CKEDITOR.ENTER_P
@@ -38,9 +38,7 @@
 				editor = bot.editor,
 				resumeAfter = bender.tools.resumeAfter,
 				observer = observeSpellCheckEvents(editor),
-				starterHtml,
-
-			starterHtml = '<p>asdf jkl dzxda</p>';
+				starterHtml = '<p>asdf jkl dzxda</p>';
 
 			bot.setData(starterHtml, function () {
 				resumeAfter(editor, 'spellCheckComplete', function () {
@@ -55,30 +53,30 @@
 
 
 	/*
-	this pattern is taken from
-	https://github.com/ckeditor/ckeditor-dev/blob/12f0de314fd6fbee0bc4d35d541123d283fdecc9/tests/plugins/filetools/fileloader.js#L131
+	 this pattern is taken from
+	 https://github.com/ckeditor/ckeditor-dev/blob/12f0de314fd6fbee0bc4d35d541123d283fdecc9/tests/plugins/filetools/fileloader.js#L131
 	 */
-	function observeSpellCheckEvents( editor ) {
-		var observer = { events: [] };
+	function observeSpellCheckEvents(editor) {
+		var observer = {events: []};
 
-		function stdObserver( evt ) {
+		function stdObserver(evt) {
 			observer.events.push(evt.name);
 		}
 
-		editor.on( 'startSpellCheckOn', stdObserver );
-		editor.on( 'startScanWords', stdObserver );
-		editor.on( 'startCheckWordsAjax', stdObserver );
-		editor.on( 'startMarkTypos', stdObserver );
-		editor.on( 'spellCheckComplete', stdObserver );
+		editor.on('startSpellCheckOn', stdObserver);
+		editor.on('startScanWords', stdObserver);
+		editor.on('startCheckWordsAjax', stdObserver);
+		editor.on('startMarkTypos', stdObserver);
+		editor.on('spellCheckComplete', stdObserver);
 
-		observer.assert = function( expected ) {
+		observer.assert = function (expected) {
 			var events = observer.events;
 
-			assert.areSame( expected.length, events.length,
-				'Events and expected length should be the same. Actual events:\n' + observer.events );
+			assert.areSame(expected.length, events.length,
+				'Events and expected length should be the same. Actual events:\n' + observer.events);
 
-			for ( var i = 0; i < events.length; i++ ) {
-				assert.areSame( expected[ i ], events[ i ] );
+			for (var i = 0; i < events.length; i++) {
+				assert.areSame(expected[i], events[i]);
 			}
 		};
 

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -1,0 +1,85 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: nanospell */
+
+'use strict';
+
+(function() {
+	bender.editor = {
+		config: {
+			enterMode: CKEDITOR.ENTER_P
+		}
+	};
+
+	bender.test({
+		setUp: function () {
+			this.server = sinon.fakeServer.create();
+			this.server.respondImmediately = true;
+			var suggestions = {
+				"result": {
+					"asdf": ["abba"],
+					"jkl": ["joke"],
+					"dzxda": ["dandy", "doody"]
+				}
+			};
+
+			this.server.respondWith(
+				'/spellcheck/nano/',
+				JSON.stringify(suggestions)
+			);
+		},
+		tearDown: function () {
+			this.server.restore();
+		},
+		'test event fires spellCheckComplete when done': function () {
+			var bot = this.editorBot,
+				editor = bot.editor,
+				resumeAfter = bender.tools.resumeAfter,
+				observer = observeSpellCheckEvents(editor),
+				starterHtml,
+
+			starterHtml = '<p>asdf jkl dzxda</p>';
+
+			bot.setData(starterHtml, function () {
+				resumeAfter(editor, 'spellCheckComplete', function () {
+					observer.assert(["spellCheckComplete", "startMarkTypos", "startCheckWordsAjax", "startScanWords"])
+				});
+
+				wait();
+			});
+
+		}
+	});
+
+
+	/*
+	this pattern is taken from
+	https://github.com/ckeditor/ckeditor-dev/blob/12f0de314fd6fbee0bc4d35d541123d283fdecc9/tests/plugins/filetools/fileloader.js#L131
+	 */
+	function observeSpellCheckEvents( editor ) {
+		var observer = { events: [] };
+
+		function stdObserver( evt ) {
+			observer.events.push(evt.name);
+		}
+
+		editor.on( 'startSpellCheckOn', stdObserver );
+		editor.on( 'startScanWords', stdObserver );
+		editor.on( 'startCheckWordsAjax', stdObserver );
+		editor.on( 'startMarkTypos', stdObserver );
+		editor.on( 'spellCheckComplete', stdObserver );
+
+		observer.assert = function( expected ) {
+			var events = observer.events;
+
+			assert.areSame( expected.length, events.length,
+				'Events and expected length should be the same. Actual events:\n' + observer.events );
+
+			for ( var i = 0; i < events.length; i++ ) {
+				assert.areSame( expected[ i ], events[ i ] );
+			}
+		};
+
+		return observer;
+	}
+
+})();

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -14,6 +14,9 @@
 		setUp: function () {
 			this.server = sinon.fakeServer.create();
 			this.server.respondImmediately = true;
+
+			// for these tests we don't really care that much about the
+			// mock data, just that it returns something vaguely resembling it
 			var suggestions = {
 				"result": {
 					"asdf": ["abba"],
@@ -30,7 +33,7 @@
 		tearDown: function () {
 			this.server.restore();
 		},
-		'test event fires spellCheckComplete when done': function () {
+		'test it emits events when going through the spellcheck cycle': function () {
 			var bot = this.editorBot,
 				editor = bot.editor,
 				resumeAfter = bender.tools.resumeAfter,


### PR DESCRIPTION
Events will let us better write tests that test the spellcheck end to end.  For example we'll be able to mock HTTP properly to have certain words be typos, or cause certain steps to fail, make sure certain words were passed along, etc.
