### PR TITLE
Parallel

### DIFF
--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -355,7 +355,9 @@
 			}
 
 			function checkNow(rootElement) {
-				if (!selectionCollapsed()) {
+				rootElement = rootElement || editor.editable();
+
+				if (!selectionCollapsed() || spellCheckInProgress(rootElement)) {
 					self._timer = null;
 					startSpellCheckTimer(DEFAULT_DELAY, rootElement);
 					return;
@@ -368,7 +370,7 @@
 
 			function scanWords(event) {
 				var words,
-					rootElement = event.data || editor.editable(),
+					rootElement = event.data,
 					range = editor.createRange();
 
 				range.selectNodeContents(rootElement);
@@ -590,18 +592,13 @@
 				var block;
 				var iterator = range.createIterator();
 				while (( block = iterator.getNextParagraph() )) {
-					if (!spellCheckInProgress(block)) {
-						block.setCustomData('spellCheckInProgress', true);
-						var unknownWords = getUnknownWords(block.getText());
-						startCheckOrMark(unknownWords, block);
-					}
-					else {
-						setTimeout(checkNow, DEFAULT_DELAY, block);
-					}
+					block.setCustomData('spellCheckInProgress', true);
+					var unknownWords = getUnknownWords(block.getText());
+					startCheckOrMarkWords(unknownWords, block);
 				}
 			}
 
-			function startCheckOrMark(words, rootElement) {
+			function startCheckOrMarkWords(words, rootElement) {
 				if (words.length > 0) {
 					editor.fire(EVENT_NAMES.START_CHECK_WORDS, {
 						words: words,

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -484,18 +484,14 @@
 
 			function render(event) {
 				var bookmarks = editor.getSelection().createBookmarks(true),
-					rootElement = event.data;
+					rootElement = event.data,
+					range = editor.createRange();
 
-				if (!rootElement) {
-					clearAllSpellCheckingSpans(editor.editable());
-					self.markAllTypos(editor);
-				} else {
-					clearAllSpellCheckingSpans(rootElement);
-					var range = editor.createRange();
+				clearAllSpellCheckingSpans(rootElement);
 
-					range.selectNodeContents(rootElement);
-					self.markTyposInRange(editor, range);
-				}
+				range.selectNodeContents(rootElement);
+				self.markTyposInRange(editor, range);
+
 				editor.getSelection().selectBookmarks(bookmarks);
 
 				self._spellCheckInProgress = false;

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -45,7 +45,8 @@
 		START_SCAN_WORDS: 'startScanWords',
 		START_CHECK_WORDS: 'startCheckWordsAjax',
 		START_RENDER: 'startRender',
-		SPELLCHECK_COMPLETE: 'spellCheckComplete'
+		SPELLCHECK_COMPLETE: 'spellCheckComplete',
+		SPELLCHECK_ABORT: 'spellCheckAbort'
 	};
 
 	function normalizeQuotes(word) {
@@ -360,6 +361,7 @@
 				if (!selectionCollapsed() || spellCheckInProgress(rootElement)) {
 					self._timer = null;
 					startSpellCheckTimer(DEFAULT_DELAY, rootElement);
+					editor.fire(EVENT_NAMES.SPELLCHECK_ABORT, rootElement);
 					return;
 				}
 				if (commandIsActive) {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -177,9 +177,6 @@
 		init: function (editor) {
 			var self = this;
 
-			// a lock to prevent multiple spellchecks
-			this._spellCheckInProgress = false;
-
 			// store the current timer
 			this._timer = null;
 
@@ -358,14 +355,12 @@
 			}
 
 			function checkNow(rootElement) {
-				if (!selectionCollapsed() || self._spellCheckInProgress) {
+				if (!selectionCollapsed()) {
 					self._timer = null;
 					startSpellCheckTimer(DEFAULT_DELAY, rootElement);
 					return;
 				}
 				if (commandIsActive) {
-
-					self._spellCheckInProgress = true;
 
 					editor.fire(EVENT_NAMES.START_SCAN_WORDS, rootElement);
 				}
@@ -516,7 +511,6 @@
 				editor.getSelection().selectBookmarks(bookmarks);
 
 				rootElement.setCustomData('spellCheckInProgress', false);
-				self._spellCheckInProgress = false;
 				self._timer = null;
 				editor.fire(EVENT_NAMES.SPELLCHECK_COMPLETE);
 			}

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -579,11 +579,19 @@
 				var iterator = range.createIterator();
 				while (( block = iterator.getNextParagraph() )) {
 					var unknownWords = getUnknownWords(block.getText());
-					// TODO: add event handler to call START_MARK_TYPOS if no words returned
+					startCheckOrMark(unknownWords, block);
+				}
+			}
+
+			function startCheckOrMark(words, rootElement) {
+				if (words.length > 0) {
 					editor.fire(EVENT_NAMES.START_CHECK_WORDS, {
-						words: unknownWords,
-						root: block
+						words: words,
+						root: rootElement
 					});
+				}
+				else {
+					editor.fire(EVENT_NAMES.START_MARK_TYPOS, rootElement);
 				}
 			}
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -418,10 +418,9 @@
 
 			function findNearestParentBlock(element) {
 				var elementPath = new CKEDITOR.dom.elementPath(element),
-					elements = elementPath.elements,
-					i;
+					elements = elementPath.elements;
 
-				for (i in elements) {
+				for (var i = 0; i < elements.length; i++) {
 					var name = elements[i].getName();
 					if (CKEDITOR.dtd.$block[name]) {
 						return elements[i];
@@ -612,10 +611,9 @@
 
 			function spellCheckInProgress(element) {
 				var elementPath = new CKEDITOR.dom.elementPath(element),
-					elements = elementPath.elements,
-					i;
+					elements = elementPath.elements;
 
-				for (i in elements) {
+				for (var i = 0; i < elements.length; i++) {
 					if (elements[i].getCustomData('spellCheckInProgress') === true) {
 						return true;
 					}

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -415,7 +415,7 @@
 				return node.getName() === 'span' && node.hasClass('nanospell-typo');
 			}
 
-			function send(event) {
+			function checkWords(event) {
 				var words = event.data.words;
 				var rootElement = event.data.root;
 				var url = resolveAjaxHandler();
@@ -427,7 +427,7 @@
 				rpc(url, data, callback);
 			}
 
-			editor.on(EVENT_NAMES.START_CHECK_WORDS, send, self);
+			editor.on(EVENT_NAMES.START_CHECK_WORDS, checkWords, self);
 
 			function wordsToRPC(words, lang) {
 				return '{"id":"c0","method":"spellcheck","params":{"lang":"' + lang + '","words":["' + words.join('","') + '"]}}'

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -410,12 +410,26 @@
 				var spellCheckSpan = elementPath.contains(isSpellCheckSpan);
 
 				if (spellCheckSpan) {
+					target = findNearestParentBlock(target);
 					var bookmarks = editor.getSelection().createBookmarks(true);
 					unwrapTypoSpan(spellCheckSpan);
 					editor.getSelection().selectBookmarks(bookmarks);
 				}
 
 				triggerSpelling((spellFastAfterSpacebar && (ch8r === CHARCODES.SPACE || ch8r === CHARCODES.LF || ch8r === CHARCODES.CR)), target)
+			}
+
+			function findNearestParentBlock(element) {
+				var elementPath = new CKEDITOR.dom.elementPath(element),
+					elements = elementPath.elements,
+					i;
+
+				for (i in elements) {
+					var name = elements[i].getName();
+					if (CKEDITOR.dtd.$block[name]) {
+						return elements[i];
+					}
+				}
 			}
 
 			function isSpellCheckSpan(node) {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -44,7 +44,7 @@
 		START_SPELLCHECK_ON: 'startSpellCheckOn',
 		START_SCAN_WORDS: 'startScanWords',
 		START_CHECK_WORDS: 'startCheckWordsAjax',
-		START_MARK_TYPOS: 'startMarkTypos',
+		START_RENDER: 'startRender',
 		SPELLCHECK_COMPLETE: 'spellCheckComplete'
 	};
 
@@ -421,7 +421,7 @@
 				var url = resolveAjaxHandler();
 				var callback = function (data) {
 					parseRpc(data, words);
-					editor.fire(EVENT_NAMES.START_MARK_TYPOS, rootElement);
+					editor.fire(EVENT_NAMES.START_RENDER, rootElement);
 				};
 				var data = wordsToRPC(words, lang);
 				rpc(url, data, callback);
@@ -503,7 +503,7 @@
 				editor.fire(EVENT_NAMES.SPELLCHECK_COMPLETE);
 			}
 
-			editor.on(EVENT_NAMES.START_MARK_TYPOS, render, self);
+			editor.on(EVENT_NAMES.START_RENDER, render, self);
 
 			function clearAllSpellCheckingSpans(element) {
 				var spans = element.find('span.nanospell-typo');
@@ -591,7 +591,7 @@
 					});
 				}
 				else {
-					editor.fire(EVENT_NAMES.START_MARK_TYPOS, rootElement);
+					editor.fire(EVENT_NAMES.START_RENDER, rootElement);
 				}
 			}
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -366,22 +366,11 @@
 
 			function scanWords(event) {
 				var words,
-					rootElement = event.data;
-				if (rootElement) {
-					var range = editor.createRange();
-					range.selectNodeContents(rootElement);
-					words = getWordsInRange(range);
-				} else {
-					words = getAllWords();
-				}
-				if (words.length == 0) {
-					editor.fire(EVENT_NAMES.START_MARK_TYPOS, rootElement);
-				} else {
-					editor.fire(EVENT_NAMES.START_CHECK_WORDS, {
-						words: words,
-						root: rootElement
-					});
-				}
+					rootElement = event.data || editor.editable(),
+					range = editor.createRange();
+
+				range.selectNodeContents(rootElement);
+				scanWordsInRange(range);
 			}
 
 			editor.on(EVENT_NAMES.START_SCAN_WORDS, scanWords, self);
@@ -585,26 +574,17 @@
 			/*
 			 for a given range, get the unique words in it that we don't have a spellcheck status for
 			 */
-			function getWordsInRange(range) {
-				var block,
-					fullTextContext = '';
+			function scanWordsInRange(range) {
+				var block;
 				var iterator = range.createIterator();
 				while (( block = iterator.getNextParagraph() )) {
-					fullTextContext += block.getText() + ' ';
+					var words = getWordsInCorpus(block.getText());
+					// TODO: add event handler to call START_MARK_TYPOS if no words returned
+					editor.fire(EVENT_NAMES.START_CHECK_WORDS, {
+						words: words,
+						root: block
+					});
 				}
-
-				return getWordsInCorpus(fullTextContext);
-			}
-
-			/*
-			 for the entire document, get the unique words in it that we don't have a spellcheck status for
-			 */
-			function getAllWords() {
-				var range = editor.createRange();
-
-				range.selectNodeContents(editor.editable());
-
-				return getWordsInRange(range);
 			}
 
 			function addPersonal(word) {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -515,6 +515,7 @@
 
 				editor.getSelection().selectBookmarks(bookmarks);
 
+				rootElement.setCustomData('spellCheckInProgress', false);
 				self._spellCheckInProgress = false;
 				self._timer = null;
 				editor.fire(EVENT_NAMES.SPELLCHECK_COMPLETE);
@@ -595,8 +596,14 @@
 				var block;
 				var iterator = range.createIterator();
 				while (( block = iterator.getNextParagraph() )) {
-					var unknownWords = getUnknownWords(block.getText());
-					startCheckOrMark(unknownWords, block);
+					if (!spellCheckInProgress(block)) {
+						block.setCustomData('spellCheckInProgress', true);
+						var unknownWords = getUnknownWords(block.getText());
+						startCheckOrMark(unknownWords, block);
+					}
+					else {
+						setTimeout(checkNow, DEFAULT_DELAY, block);
+					}
 				}
 			}
 
@@ -610,6 +617,19 @@
 				else {
 					editor.fire(EVENT_NAMES.START_RENDER, rootElement);
 				}
+			}
+
+			function spellCheckInProgress(element) {
+				var elementPath = new CKEDITOR.dom.elementPath(element),
+					elements = elementPath.elements,
+					i;
+
+				for (i in elements) {
+					if (elements[i].getCustomData('spellCheckInProgress') === true) {
+						return true;
+					}
+				}
+				return false;
 			}
 
 			function addPersonal(word) {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -554,8 +554,8 @@
 			/*
 			 Given some text, get the unique words in it that we don't have a spellcheck status for
 			 */
-			function getWordsInCorpus(corpus) {
-				var matches = corpus.match(wordTokenizer());
+			function getUnknownWords(text) {
+				var matches = text.match(wordTokenizer());
 				var uniqueWords = [];
 				var words = [];
 				if (!matches) {
@@ -578,10 +578,10 @@
 				var block;
 				var iterator = range.createIterator();
 				while (( block = iterator.getNextParagraph() )) {
-					var words = getWordsInCorpus(block.getText());
+					var unknownWords = getUnknownWords(block.getText());
 					// TODO: add event handler to call START_MARK_TYPOS if no words returned
 					editor.fire(EVENT_NAMES.START_CHECK_WORDS, {
-						words: words,
+						words: unknownWords,
 						root: block
 					});
 				}

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -48,7 +48,7 @@
 
 			bot.setData(starterHtml, function () {
 				resumeAfter(editor, 'spellCheckComplete', function () {
-					observer.assert(["spellCheckComplete", "startMarkTypos", "startCheckWordsAjax", "startScanWords"])
+					observer.assert(["spellCheckComplete", "startRender", "startCheckWordsAjax", "startScanWords"])
 				});
 
 				// start spellcheck
@@ -65,11 +65,13 @@
 				// TODO - add a helper API to clear cached suggestions
 				// this requires one unique word over the previous test
 				// if the entire suite is run
-				starterHtml = '<p>asdf jkl dzxda psd</p><p>asdf jkl^</p>';
+				starterHtml = '<p>asdf jkl dzxda psd</p><p>asdf ndskn jkl^</p>';
 
 			function triggerSecondParagraphSpellcheck() {
-				// first run
-				observer.assert(["spellCheckComplete", "startMarkTypos", "startCheckWordsAjax", "startScanWords"]);
+				// first run checks the whole document.  Since the spellcheck first
+				// splits the document into blocks, all events other than
+				// "startScanWords" will be fired twice.
+				observer.assert(["spellCheckComplete", "startRender", "startCheckWordsAjax", "spellCheckComplete", "startRender", "startCheckWordsAjax", "startScanWords"]);
 
 				// make a new observer to clear the events
 
@@ -93,7 +95,7 @@
 				var secondParagraph = editor.editable().getChild(1);
 
 				// no ajax call required on the second run, since words are repeats.
-				observer.assert(["spellCheckComplete", "startMarkTypos", "startScanWords"]);
+				observer.assert(["spellCheckComplete", "startRender", "startScanWords"]);
 				observer.assertRootIs(secondParagraph);
 			}
 
@@ -123,7 +125,7 @@
 		editor.on('startSpellCheckOn', stdObserver);
 		editor.on('startScanWords', stdObserver);
 		editor.on('startCheckWordsAjax', stdObserver);
-		editor.on('startMarkTypos', stdObserver);
+		editor.on('startRender', stdObserver);
 		editor.on('spellCheckComplete', stdObserver);
 
 		observer.assert = function (expected) {

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -145,7 +145,8 @@
 				i,
 				root;
 
-			for (i=0, event=events[i]; i<events.length; i++) {
+			for (i=0; i<events.length; i++) {
+				event = events[i];
 				if (event.name === 'spellCheckComplete') {
 					continue;
 				} else if (event.name === 'startCheckWordsAjax') {


### PR DESCRIPTION
Changes initial document spellcheck to be split into block-level elements so they can occur in parallel.  Also fixes a bug that caused changes to text inside a spellcheck span to trigger a whole-document spellcheck
