### PR TITLE
Add block request limit to reduce number of ajax calls on initial load

### DIFF
--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -193,6 +193,8 @@
 				this.settings = {};
 			}
 			lang = this.settings.dictionary || lang;
+			// set the maximum number of block elements spellchecked per AJAX request
+			var BLOCK_REQUEST_LIMIT = this.settings.blockRequestLimit || BLOCK_REQUEST_LIMIT;
 			editor.addCommand('nanospell', {
 				exec: function (editor) {
 					if (!commandIsActive) {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -195,7 +195,6 @@
 			lang = this.settings.dictionary || lang;
 			// set the maximum number of block elements spellchecked per AJAX request
 			BLOCK_REQUEST_LIMIT = this.settings.blockRequestLimit || BLOCK_REQUEST_LIMIT;
-			debugger;
 			editor.addCommand('nanospell', {
 				exec: function (editor) {
 					if (!commandIsActive) {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -194,7 +194,8 @@
 			}
 			lang = this.settings.dictionary || lang;
 			// set the maximum number of block elements spellchecked per AJAX request
-			var BLOCK_REQUEST_LIMIT = this.settings.blockRequestLimit || BLOCK_REQUEST_LIMIT;
+			BLOCK_REQUEST_LIMIT = this.settings.blockRequestLimit || BLOCK_REQUEST_LIMIT;
+			debugger;
 			editor.addCommand('nanospell', {
 				exec: function (editor) {
 					if (!commandIsActive) {

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -175,6 +175,8 @@
 						// stop the plugin
 						editor.execCommand('nanospell');
 
+						// reset data with six-block html. Confirms that an additional AJAX
+						// call occurs when the number of blocks is increased over the limit
 						bot.setData(sixBlockHtml, function () {
 							resumeAfter(editor, 'spellCheckComplete', function () {
 								observer.assertAjaxCalls(2);

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -70,8 +70,8 @@
 			function triggerSecondParagraphSpellcheck() {
 				// first run checks the whole document.  Since the spellcheck first
 				// splits the document into blocks, all events other than
-				// "startScanWords" will be fired twice.
-				observer.assert(["spellCheckComplete", "startRender", "startCheckWordsAjax", "spellCheckComplete", "startRender", "startCheckWordsAjax", "startScanWords"]);
+				// "startScanWords" and "startCheckWordsAjax" will be fired twice.
+				observer.assert(["spellCheckComplete", "startRender", "spellCheckComplete", "startRender", "startCheckWordsAjax", "startScanWords"]);
 
 				// make a new observer to clear the events
 
@@ -130,7 +130,7 @@
 
 				function completeFirstSpellcheck() {
 
-					observer.assert(["spellCheckComplete", "startRender", "startCheckWordsAjax", "spellCheckComplete", "startRender", "startCheckWordsAjax", "startScanWords"]);
+					observer.assert(["spellCheckComplete", "startRender", "spellCheckComplete", "startRender", "startCheckWordsAjax", "startScanWords"]);
 
 					// set outer li to show that a spellcheck is in progress
 					outer.setCustomData('spellCheckInProgress', true);

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -162,7 +162,7 @@
 				resumeAfter = bender.tools.resumeAfter,
 				observer = observeSpellCheckEvents(editor),
 				fiveBlockHtml = '<p>This</p><p>is</p><ul><li>five</li><li>block</li></ul><p>test</p>',
-				sixBlockHtml = '<p>This</p><p>is</p><p>a</p><ul><li>six</li><li>block</li></ul><p>test</p>';
+				sixBlockHtml = '<p>This</p><p>is</p><p>a</p><ul><li>six</li><li>block</li></ul><p>one</p>';
 
 				// this test assumes that the BLOCK_REQUEST_LIMIT is set to the default
 				// of 5 blocks per AJAX request

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -8,7 +8,8 @@
 		config: {
 			enterMode: CKEDITOR.ENTER_P,
 			nanospell: {
-				autostart: false
+				autostart: false,
+				blockRequestLimit: 5
 			}
 		}
 	};
@@ -163,9 +164,6 @@
 				observer = observeSpellCheckEvents(editor),
 				fiveBlockHtml = '<p>This</p><p>is</p><ul><li>five</li><li>block</li></ul><p>test</p>',
 				sixBlockHtml = '<p>This</p><p>is</p><p>a</p><ul><li>six</li><li>block</li></ul><p>one</p>';
-
-				// this test assumes that the BLOCK_REQUEST_LIMIT is set to the default
-				// of 5 blocks per AJAX request
 
 				bot.setData(fiveBlockHtml, function () {
 					resumeAfter(editor, 'spellCheckComplete', function () {


### PR DESCRIPTION
This will batch word checks sent to the spellcheck API to reduce the overall number of requests, while still maintaining parallel rendering after the response is received. The number of blocks combined per request can be modified with the BLOCK_REQUEST_LIMIT at the top of the plugin.js file.
