### PR TITLE
Use store.js to deal with missing localstorage, if available

### DIFF
--- a/bender.js
+++ b/bender.js
@@ -48,8 +48,9 @@ var config = {
             basePath: 'tests/',
             paths: [
                 'smoke/**',
-				        'typowalking/**',
+				'typowalking/**',
                 'spellchecking/**',
+				'suggestions/**',
                 '!**/_*/**'
             ],
             // Latest of the old API (1.8.3)

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -78,7 +78,7 @@
 				blockIsStartNode = block && block.equals(startNode),
 				blockLimit = path.blockLimit,
 				blockLimitIsStartNode = blockLimit && blockLimit.equals(startNode),
-				isInSpellCheckSpan = path.contains(function(el) {
+				isInSpellCheckSpan = path.contains(function (el) {
 					return el.getName() === 'span' && el.hasClass('nanospell-typo');
 				})
 
@@ -101,7 +101,7 @@
 			if (!condition) {
 				if (node.type == CKEDITOR.NODE_ELEMENT &&
 					isNotBookmark(node) &&
-				 	((blockLimit && !blockLimitIsStartNode) ||
+					((blockLimit && !blockLimitIsStartNode) ||
 					(block && !blockIsStartNode) ||
 					node.is('br', 'sup', 'sub'))) {
 
@@ -168,7 +168,7 @@
 				// text nodes but we traversed an element that should cause a word break
 				if (text && i === text.length && ww.hitWordBreak) {
 					ww.hitWordBreak = false;
-					if (word) return { word: word, range: wordRange };
+					if (word) return {word: word, range: wordRange};
 				}
 				text = currentTextNode.getText();
 				for (i = ww.offset; i < text.length; i++) {
@@ -177,7 +177,7 @@
 						wordRange.setEnd(currentTextNode, i);
 
 						ww.offset = ww.getOffsetToNextNonSeparator(text, i);
-						if (word) return { word: word, range: wordRange };
+						if (word) return {word: word, range: wordRange};
 					}
 				}
 				word += text.substr(ww.offset);
@@ -190,8 +190,67 @@
 			// reached the end of block,
 			// so just return what we've walked
 			// of the current word.
-			if (word) return { word: word, range: wordRange };
+			if (word) return {word: word, range: wordRange};
 		}
+	};
+
+	function SuggestionsStorage() {
+		this.enabled = false;
+
+		if (typeof store !== "undefined" && store.enabled) {
+			this.enabled = true;
+			this.addPersonal = this.addPersonalStoreJs;
+			this.hasPersonal = this.hasPersonalStoreJs;
+		} else {
+			try {
+				localStorage.getItem;
+				this.enabled = true;
+				this.addPersonal = this.addPersonalLocalStorage;
+				this.hasPersonal = this.hasPersonalLocalStorage;
+			} catch (exception) {
+			}
+		}
+	}
+
+	SuggestionsStorage.prototype = {
+		addPersonalLocalStorage: function (word) {
+			// original nanospell code
+			var value = localStorage.getItem('nano_spellchecker_personal');
+			if (value !== null && value !== "") {
+				value += String.fromCharCode(127);
+			} else {
+				value = "";
+			}
+			value += word.toLowerCase();
+			localStorage.setItem('nano_spellchecker_personal', value);
+		},
+		addPersonalStoreJs: function (word) {
+			var suggestions = store.get('nanospell_suggestions') || [];
+
+			if (suggestions.indexOf(word) !== -1) return;
+
+			suggestions.push(word);
+			store.set('nanospell_suggestions', suggestions);
+		},
+		hasPersonalLocalStorage: function (word) {
+			var value = localStorage.getItem('nano_spellchecker_personal');
+			if (value === null || value == "") {
+				return false;
+			}
+			var records = value.split(String.fromCharCode(127));
+			word = word.toLowerCase();
+			for (var i = 0; i < records.length; i++) {
+				if (records[i] === word) {
+					return true;
+				}
+			}
+			return false;
+		},
+		hasPersonalStoreJs: function (word) {
+			var suggestions = store.get('nanospell_suggestions') || [];
+			return (suggestions.indexOf(word) !== -1);
+		}
+
 	};
 
 	CKEDITOR.plugins.add('nanospell', {
@@ -213,6 +272,7 @@
 				this.settings = {};
 			}
 			lang = this.settings.dictionary || lang;
+			this.suggestions = new SuggestionsStorage();
 			// set the maximum number of block elements spellchecked per AJAX request
 			BLOCK_REQUEST_LIMIT = this.settings.blockRequestLimit || BLOCK_REQUEST_LIMIT;
 			editor.addCommand('nanospell', {
@@ -226,7 +286,7 @@
 				editorFocus: true
 			});
 			editor.addCommand('nanospellReset', {
-				exec: function(editor) {
+				exec: function (editor) {
 					spellcache = [];
 					suggestionscache = [];
 					ignorecache = [];
@@ -354,12 +414,12 @@
 
 					retobj["nanopell_ignore"] = CKEDITOR.TRISTATE_OFF;
 					//
-					if (localStorage) {
+					if (self.suggestions.enabled) {
 						editor.addMenuItem('nanopell_learn', {
 							label: locale.learn,
 							group: 'nanotools',
 							onClick: function () {
-								addPersonal(typo);
+								self.addPersonal(typo);
 								ignoreWord(element.$, typo, true);
 							}
 						});
@@ -647,7 +707,7 @@
 				range.selectNodeContents(block);
 				var wordwalker = new self.WordWalker(range);
 
-				while(word = wordwalker.getNextWord()) {
+				while (word = wordwalker.getNextWord()) {
 					words.push(word.word);
 				}
 				return words.join(" ");
@@ -661,7 +721,7 @@
 					});
 				}
 				else {
-					for (var i = 0; i < blockList.length; i++){
+					for (var i = 0; i < blockList.length; i++) {
 						var rootElement = blockList[i];
 						editor.fire(EVENT_NAMES.START_RENDER, rootElement);
 					}
@@ -671,20 +731,9 @@
 			function spellCheckInProgress(element) {
 				var elementPath = new CKEDITOR.dom.elementPath(element);
 
-				return elementPath.contains(function(el) {
+				return elementPath.contains(function (el) {
 					return (el.getCustomData('spellCheckInProgress') === true)
 				})
-			}
-
-			function addPersonal(word) {
-				var value = localStorage.getItem('nano_spellchecker_personal');
-				if (value !== null && value !== "") {
-					value += String.fromCharCode(127);
-				} else {
-					value = "";
-				}
-				value += word.toLowerCase();
-				localStorage.setItem('nano_spellchecker_personal', value);
 			}
 
 			function getSuggestions(word) {
@@ -840,19 +889,11 @@
 				removeFormatFilter.call(editor, removeFormatFilterTemplate);
 			}
 		},
+		addPersonal: function (word) {
+			return this.suggestions.addPersonal(word);
+		},
 		hasPersonal: function (word) {
-			var value = localStorage.getItem('nano_spellchecker_personal');
-			if (value === null || value == "") {
-				return false;
-			}
-			var records = value.split(String.fromCharCode(127));
-			word = word.toLowerCase();
-			for (var i = 0; i < records.length; i++) {
-				if (records[i] === word) {
-					return true;
-				}
-			}
-			return false;
+			return this.suggestions.hasPersonal(word);
 		},
 		validWordToken: function (word) {
 			if (!word) {
@@ -924,7 +965,8 @@
 				this.wrapWithTypoSpan(editor, currRange);
 			}
 		},
-		WordWalker: WordWalker
+		WordWalker: WordWalker,
+		SuggestionsStorage: SuggestionsStorage
 	});
 
 })();

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -197,11 +197,18 @@
 	function SuggestionsStorage() {
 		this.enabled = false;
 
-		if (typeof store !== "undefined" && store.enabled) {
-			this.enabled = true;
-			this.addPersonal = this.addPersonalStoreJs;
-			this.hasPersonal = this.hasPersonalStoreJs;
-		} else {
+		//
+		if (typeof store !== "undefined" ) {
+			if (store.enabled) {
+				this.enabled = true;
+				this.addPersonal = this.addPersonalStoreJs;
+				this.hasPersonal = this.hasPersonalStoreJs;
+			}
+			// if store is not undefined, but store is disabled
+			// we don't want to proceed to the localStorage case,
+			// since store will have already done this detection for us
+		} else if (localStorage) { // localStorage can be disabled entirely (localStorage === null)
+			// localStorage can also just throw exceptions due to a security policy
 			try {
 				localStorage.getItem('test');
 				this.enabled = true;
@@ -216,7 +223,7 @@
 		addPersonalLocalStorage: function (word) {
 			// original nanospell code
 			var value = localStorage.getItem('nano_spellchecker_personal');
-			if (value !== null && value !== "") {
+			if (value) {
 				value += String.fromCharCode(127);
 			} else {
 				value = "";

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -203,7 +203,7 @@
 			this.hasPersonal = this.hasPersonalStoreJs;
 		} else {
 			try {
-				localStorage.getItem;
+				localStorage.getItem('test');
 				this.enabled = true;
 				this.addPersonal = this.addPersonalLocalStorage;
 				this.hasPersonal = this.hasPersonalLocalStorage;

--- a/tests/suggestions/securityexception.js
+++ b/tests/suggestions/securityexception.js
@@ -14,12 +14,30 @@
 		setUp: function() {
 //			this.suggestions = new editor.plugins.nanospell.SuggestionsStorage();
 		},
-		'test when exception occurs with localStorage it is disabled': function() {
-			var suggestions = new editor.plugins.nanospell.SuggestionsStorage();
-			var mockedStorage = sinon.mock(localStorage);
-			mockedStorage.expects('getItem').once().throws();
+		'test it uses storejs when enabled': function() {
+			var editor = this.editorBot.editor;
+			var storeStub = sinon.stub();
+			window.store = storeStub;
+			storeStub.enabled = true;
 
-			assert.isFalse(suggestions.enabled);
+			var suggestions = new editor.plugins.nanospell.SuggestionsStorage();
+
+			assert.isTrue(suggestions.enabled);
+			assert.areEqual(suggestions.addPersonalStoreJs, suggestions.addPersonal);
+			assert.areEqual(suggestions.hasPersonalStoreJs, suggestions.hasPersonal);
+
+
+			// this cleanup is required only for this test, since we filled in window.store earlier
+			delete window.store;
+		},
+		'test it falls back on localStorage': function() {
+			var editor = this.editorBot.editor;
+
+			var suggestions = new editor.plugins.nanospell.SuggestionsStorage();
+
+			assert.isTrue(suggestions.enabled);
+			assert.areEqual(suggestions.addPersonalLocalStorage, suggestions.addPersonal);
+			assert.areEqual(suggestions.hasPersonalLocalStorage, suggestions.hasPersonal);
 		}
 
 	});

--- a/tests/suggestions/securityexception.js
+++ b/tests/suggestions/securityexception.js
@@ -1,0 +1,27 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: nanospell */
+
+'use strict';
+
+(function () {
+	bender.editor = {
+		config: {
+			enterMode: CKEDITOR.ENTER_P
+		}
+	};
+
+	bender.test({
+		setUp: function() {
+//			this.suggestions = new editor.plugins.nanospell.SuggestionsStorage();
+		},
+		'test when exception occurs with localStorage it is disabled': function() {
+			var suggestions = new editor.plugins.nanospell.SuggestionsStorage();
+			var mockedStorage = sinon.mock(localStorage);
+			mockedStorage.expects('getItem').once().throws();
+
+			assert.isFalse(suggestions.enabled);
+		}
+
+	});
+
+})();

--- a/tests/suggestions/storejs.js
+++ b/tests/suggestions/storejs.js
@@ -45,6 +45,39 @@
 
 			assert.isTrue(setSpy.calledWith('nanospell_suggestions', ['foo', 'asdf']));
 		},
+		'test it does not call set if the word is a duplicate': function() {
+			var editor = this.editorBot.editor;
+			var getStub = sinon.stub();
+			getStub.returns(['foo']);
+			window.store.get = getStub;
+
+			var setSpy = sinon.spy();
+			window.store.set = setSpy;
+
+			var suggestions = new editor.plugins.nanospell.SuggestionsStorage();
+			suggestions.addPersonal('foo');
+
+			assert.isFalse(setSpy.called);
+		},
+		'test it provides no suggestions if none have been added': function() {
+			// vs just crashing. which it did.
+			var editor = this.editorBot.editor;
+			var getStub = sinon.stub();
+			getStub.returns(null);
+			window.store.get = getStub;
+
+			var suggestions = new editor.plugins.nanospell.SuggestionsStorage();
+			assert.isFalse(suggestions.hasPersonal('asdf'));
+		},
+		'test it returns true if the suggestion is in the store': function() {
+			var editor = this.editorBot.editor;
+			var getStub = sinon.stub();
+			getStub.returns(['foo', 'bar', 'baz', 'asdf']);
+			window.store.get = getStub;
+
+			var suggestions = new editor.plugins.nanospell.SuggestionsStorage();
+			assert.isTrue(suggestions.hasPersonal('asdf'));
+		}
 
 	});
 

--- a/tests/suggestions/storejs.js
+++ b/tests/suggestions/storejs.js
@@ -1,0 +1,51 @@
+/* bender-tags: editor,unit */
+/* bender-ckeditor-plugins: nanospell */
+
+'use strict';
+
+(function () {
+	bender.editor = {
+		config: {
+			enterMode: CKEDITOR.ENTER_P
+		}
+	};
+
+	bender.test({
+		setUp: function() {
+			window.store = {
+				enabled: true
+			};
+		},
+		'test it starts a new personal dictionary and sets it': function() {
+			var editor = this.editorBot.editor;
+			var getStub = sinon.stub();
+			getStub.returns(null);
+			window.store.get = getStub;
+
+			var setSpy = sinon.spy();
+			window.store.set = setSpy;
+
+
+			var suggestions = new editor.plugins.nanospell.SuggestionsStorage();
+			suggestions.addPersonal('asdf');
+
+			assert.isTrue(setSpy.calledWith('nanospell_suggestions', ['asdf']));
+		},
+		'test it appends to an existing personal dictionary and sets it': function() {
+			var editor = this.editorBot.editor;
+			var getStub = sinon.stub();
+			getStub.returns(['foo']);
+			window.store.get = getStub;
+
+			var setSpy = sinon.spy();
+			window.store.set = setSpy;
+
+			var suggestions = new editor.plugins.nanospell.SuggestionsStorage();
+			suggestions.addPersonal('asdf');
+
+			assert.isTrue(setSpy.calledWith('nanospell_suggestions', ['foo', 'asdf']));
+		},
+
+	});
+
+})();

--- a/tests/suggestions/storejsdetection.js
+++ b/tests/suggestions/storejsdetection.js
@@ -25,10 +25,18 @@
 			assert.isTrue(suggestions.enabled);
 			assert.areEqual(suggestions.addPersonalStoreJs, suggestions.addPersonal);
 			assert.areEqual(suggestions.hasPersonalStoreJs, suggestions.hasPersonal);
-			
+
 		},
-		'test it falls back on localStorage': function() {
+		'test it disables if not store.enabled': function() {
 			var editor = this.editorBot.editor;
+
+			var suggestions = new editor.plugins.nanospell.SuggestionsStorage();
+
+			assert.isFalse(suggestions.enabled);
+		},
+		'test it falls back on localStorage if store is undef': function() {
+			var editor = this.editorBot.editor;
+			window.store = undefined;
 
 			var suggestions = new editor.plugins.nanospell.SuggestionsStorage();
 

--- a/tests/suggestions/storejsdetection.js
+++ b/tests/suggestions/storejsdetection.js
@@ -12,7 +12,9 @@
 
 	bender.test({
 		setUp: function() {
-//			this.suggestions = new editor.plugins.nanospell.SuggestionsStorage();
+			window.store = {
+				enabled: false
+			}
 		},
 		'test it uses storejs when enabled': function() {
 			var editor = this.editorBot.editor;
@@ -23,10 +25,7 @@
 			assert.isTrue(suggestions.enabled);
 			assert.areEqual(suggestions.addPersonalStoreJs, suggestions.addPersonal);
 			assert.areEqual(suggestions.hasPersonalStoreJs, suggestions.hasPersonal);
-
-
-			// this cleanup is required only for this test, since we filled in window.store earlier
-			delete window.store;
+			
 		},
 		'test it falls back on localStorage': function() {
 			var editor = this.editorBot.editor;

--- a/tests/suggestions/storejsdetection.js
+++ b/tests/suggestions/storejsdetection.js
@@ -16,9 +16,7 @@
 		},
 		'test it uses storejs when enabled': function() {
 			var editor = this.editorBot.editor;
-			var storeStub = sinon.stub();
-			window.store = storeStub;
-			storeStub.enabled = true;
+			window.store.enabled = true;
 
 			var suggestions = new editor.plugins.nanospell.SuggestionsStorage();
 


### PR DESCRIPTION
It looks like store.js will handle the permissions problem for us.  It has a similar snippet to what Modernizr does.  Also update the non-storejs feature detection to do the modernizr technique of attempting to use a localStorage API from inside a try/catch.  
