### PR TITLE
Fix problem with incorrect spellcheck spans

### DIFF
--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -641,14 +641,16 @@
 
 			function getWords(block) {
 				var range = editor.createRange(),
+					currentWordObj,
 					words = [],
 					word;
 
 				range.selectNodeContents(block);
 				var wordwalker = new self.WordWalker(range);
 
-				while(word = wordwalker.getNextWord()) {
-					words.push(word.word);
+				while(currentWordObj = wordwalker.getNextWord()) {
+					word = currentWordObj.word;
+					if (word) words.push(word);
 				}
 				return words.join(" ");
 			}

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -190,7 +190,7 @@
 				}
 				word += text.substr(ww.offset);
 				ww.offset = 0;
-				wordRange.setEndAfter(ww.textNode);
+				wordRange.setEnd(currentTextNode, i);
 				currentTextNode = ww.rootBlockTextNodeWalker.next();
 
 				ww.textNode = currentTextNode;

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -177,7 +177,15 @@
 						wordRange.setEnd(currentTextNode, i);
 
 						ww.offset = ww.getOffsetToNextNonSeparator(text, i);
-						return { word: word, range: wordRange };
+						if (word) {
+							// if you hit a word separator and there is word text, return it
+							return { word: word, range: wordRange };
+						}
+						else {
+							// if the word is blank, set the start of the range to the next
+							// non-separator text
+							wordRange.setStart(currentTextNode, ww.offset);
+						}
 					}
 				}
 				word += text.substr(ww.offset);

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -723,14 +723,9 @@
 				range.selectNodeContents(block);
 				var wordwalker = new self.WordWalker(range);
 
-<<<<<<< HEAD
 				while(currentWordObj = wordwalker.getNextWord()) {
 					word = currentWordObj.word;
 					if (word) words.push(word);
-=======
-				while (word = wordwalker.getNextWord()) {
-					words.push(word.word);
->>>>>>> 9ed9e320c631180994c13a8e55ce1f451d22314f
 				}
 				return words.join(" ");
 			}

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -168,7 +168,7 @@
 				// text nodes but we traversed an element that should cause a word break
 				if (text && i === text.length && ww.hitWordBreak) {
 					ww.hitWordBreak = false;
-					if (word) return { word: word, range: wordRange };
+					return { word: word, range: wordRange };
 				}
 				text = currentTextNode.getText();
 				for (i = ww.offset; i < text.length; i++) {
@@ -177,7 +177,7 @@
 						wordRange.setEnd(currentTextNode, i);
 
 						ww.offset = ww.getOffsetToNextNonSeparator(text, i);
-						if (word) return { word: word, range: wordRange };
+						return { word: word, range: wordRange };
 					}
 				}
 				word += text.substr(ww.offset);
@@ -190,7 +190,7 @@
 			// reached the end of block,
 			// so just return what we've walked
 			// of the current word.
-			if (word) return { word: word, range: wordRange };
+			return { word: word, range: wordRange };
 		}
 	};
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -198,7 +198,7 @@
 			// reached the end of block,
 			// so just return what we've walked
 			// of the current word.
-			return { word: word, range: wordRange };
+			if (word) return { word: word, range: wordRange };
 		}
 	};
 

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -29,7 +29,7 @@ bender.test( {
 
 		while (currWordObj = wordwalker.getNextWord()) {
 			word = currWordObj.word;
-			if (word) wordsReturned.push(word);
+			wordsReturned.push(word);
 		}
 
 		return wordsReturned;

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -17,7 +17,10 @@ bender.test( {
 		var editor = this.editorBot.editor,
 			range,
 			wordwalker,
-			wordsReturned = [],
+			wordsReturned = {
+				ranges: [],
+				words: []
+			},
 			currWordObj,
 			word;
 
@@ -29,7 +32,9 @@ bender.test( {
 
 		while (currWordObj = wordwalker.getNextWord()) {
 			word = currWordObj.word;
-			wordsReturned.push(word);
+			range = currWordObj.range;
+			wordsReturned.words.push(word);
+			wordsReturned.ranges.push(range);
 		}
 
 		return wordsReturned;
@@ -41,8 +46,10 @@ bender.test( {
 		bot.setHtmlWithSelection( '<p>foo bar baz</p>' );
 
 		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst() );
+		rangesReturned = wordsReturned.ranges.map(function(range) { return range.extractContents().$.textContent});
 
-		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
+		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned.words);
+		arrayAssert.itemsAreEqual(wordsReturned.words, rangesReturned);
 	},
 
 	'test walking a simple paragraph with inline formats': function() {

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -42,11 +42,12 @@ bender.test( {
 
 	'test walking a simple paragraph': function() {
 		var bot = this.editorBot,
+			rangesReturned,
 			wordsReturned;
 		bot.setHtmlWithSelection( '<p>foo bar baz</p>' );
 
 		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst() );
-		rangesReturned = wordsReturned.ranges.map(function(range) { return range.extractContents().$.textContent});
+		rangesReturned = wordsReturned.ranges.map(function(range) { return range.cloneContents().$.textContent });
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned.words);
 		arrayAssert.itemsAreEqual(wordsReturned.words, rangesReturned);

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -18,7 +18,8 @@ bender.test( {
 			range,
 			wordwalker,
 			wordsReturned = [],
-			currWordObj;
+			currWordObj,
+			word;
 
 		range = new CKEDITOR.dom.range( editor.document );
 		// assume there is only one block level element.
@@ -27,7 +28,8 @@ bender.test( {
 		wordwalker = new editor.plugins.nanospell.WordWalker(range);
 
 		while (currWordObj = wordwalker.getNextWord()) {
-			wordsReturned.push(currWordObj.word);
+			word = currWordObj.word;
+			if (word) wordsReturned.push(word);
 		}
 
 		return wordsReturned;

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -39,9 +39,15 @@ bender.test( {
 
 		return wordsReturned;
 	},
+	getWordRanges: function(ranges) {
+		return ranges.map(function(range) {
+			return range.cloneContents().$.textContent;
+		});
+	},
 
 	'test walking a simple paragraph': function() {
 		var bot = this.editorBot,
+			wordObjectsReturned,
 			rangesReturned,
 			wordsReturned;
 		bot.setHtmlWithSelection( '<p>foo bar baz</p>' );

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -13,7 +13,7 @@ bender.test( {
 	setUp: function() {
 		this.editor = this.editorBot.editor;
 	},
-	getWordsWithWordWalker: function(root) {
+	getWordObjectsWithWordWalker: function(root) {
 		var editor = this.editorBot.editor,
 			range,
 			wordwalker,
@@ -52,25 +52,34 @@ bender.test( {
 			wordsReturned;
 		bot.setHtmlWithSelection( '<p>foo bar baz</p>' );
 
-		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst() );
-		rangesReturned = wordsReturned.ranges.map(function(range) { return range.cloneContents().$.textContent });
+		wordObjectsReturned = this.getWordObjectsWithWordWalker(this.editor.editable().getFirst() );
+		wordsReturned = wordObjectsReturned.words;
+		rangesReturned = this.getWordRanges(wordObjectsReturned.ranges);
 
-		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned.words);
-		arrayAssert.itemsAreEqual(wordsReturned.words, rangesReturned);
+		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
+		arrayAssert.itemsAreEqual(wordsReturned, rangesReturned);
 	},
 
 	'test walking a simple paragraph with inline formats': function() {
 		var bot = this.editorBot,
+			wordObjectsReturned,
+			rangesReturned,
 			wordsReturned;
+
 		bot.setHtmlWithSelection( '<p>f<i>o</i>o <strong>b</strong>ar <em>baz</em></p>' );
 
-		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst() );
+		wordObjectsReturned = this.getWordObjectsWithWordWalker(this.editor.editable().getFirst() );
+		wordsReturned = wordObjectsReturned.words;
+		rangesReturned = this.getWordRanges(wordObjectsReturned.ranges);
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
+		arrayAssert.itemsAreEqual(wordsReturned, rangesReturned);
 	},
 
 	'test walking a single item list': function() {
 		var bot = this.editorBot,
+			wordObjectsReturned,
+			rangesReturned,
 			wordsReturned;
 		bot.setHtmlWithSelection(
 			'<ol>' +
@@ -78,13 +87,18 @@ bender.test( {
 			'</ol>'
 		);
 
-		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst().getFirst() );
+		wordObjectsReturned = this.getWordObjectsWithWordWalker(this.editor.editable().getFirst().getFirst() );
+		wordsReturned = wordObjectsReturned.words;
+		rangesReturned = this.getWordRanges(wordObjectsReturned.ranges);
 
 		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], wordsReturned);
+		arrayAssert.itemsAreEqual(wordsReturned, rangesReturned);
 	},
 
 	'test walking multiple list items': function() {
 		var bot = this.editorBot,
+			wordObjectsReturned,
+			rangesReturned,
 			wordsReturned,
 			list;
 		bot.setHtmlWithSelection(
@@ -96,10 +110,17 @@ bender.test( {
 		);
 
 		list = this.editor.editable().getFirst();
+		var liOneWordObjects = this.getWordObjectsWithWordWalker( list.getChild(0) ),
+			liTwoWordObjects = this.getWordObjectsWithWordWalker( list.getChild(1) ),
+			liThreeWordObjects = this.getWordObjectsWithWordWalker( list.getChild(2) );
 
-		arrayAssert.itemsAreEqual(['foo', 'bar'], this.getWordsWithWordWalker( list.getChild(0) ));
-		arrayAssert.itemsAreEqual(['bar', 'baz'], this.getWordsWithWordWalker( list.getChild(1) ));
-		arrayAssert.itemsAreEqual(['baz', 'foo'], this.getWordsWithWordWalker( list.getChild(2) ));
+		arrayAssert.itemsAreEqual(['foo', 'bar'], liOneWordObjects.words);
+		arrayAssert.itemsAreEqual(['bar', 'baz'], liTwoWordObjects.words);
+		arrayAssert.itemsAreEqual(['baz', 'foo'], liThreeWordObjects.words);
+
+		arrayAssert.itemsAreEqual(liOneWordObjects.words, this.getWordRanges(liOneWordObjects.ranges));
+		arrayAssert.itemsAreEqual(liTwoWordObjects.words, this.getWordRanges(liTwoWordObjects.ranges));
+		arrayAssert.itemsAreEqual(liThreeWordObjects.words, this.getWordRanges(liThreeWordObjects.ranges));
 	},
 
 	'test walking in a double nested list': function() {

--- a/tests/typowalking/wordwalker.js
+++ b/tests/typowalking/wordwalker.js
@@ -125,7 +125,12 @@ bender.test( {
 
 	'test walking in a double nested list': function() {
 		var bot = this.editorBot,
-			wordsReturned,
+			outerWordObjectsReturned,
+			outerRangesReturned,
+			outerWordsReturned,
+			innerWordObjectsReturned,
+			innerRangesReturned,
+			innerWordsReturned,
 			outerUnorderedList,
 			innerOrderedList;
 		bot.setHtmlWithSelection(
@@ -140,18 +145,31 @@ bender.test( {
 
 		outerUnorderedList = this.editor.editable().getFirst();
 
+		outerWordObjectsReturned = this.getWordObjectsWithWordWalker( outerUnorderedList.getFirst() );
+		outerRangesReturned = this.getWordRanges(outerWordObjectsReturned.ranges);
+		outerWordsReturned = outerWordObjectsReturned.words;
+
 		innerOrderedList = outerUnorderedList.getFirst().getFirst();
+
+		innerWordObjectsReturned = this.getWordObjectsWithWordWalker( innerOrderedList.getFirst() );
+		innerRangesReturned = this.getWordRanges(innerWordObjectsReturned.ranges);
+		innerWordsReturned = innerWordObjectsReturned.words;
 
 		// due to the way that range iterators work, the `li` get passed in.
 
 		// we special-case the walker to not follow into nested blocks
 		// because of the special list case where they get passed in twice.
-		arrayAssert.itemsAreEqual([], this.getWordsWithWordWalker( outerUnorderedList.getFirst() ));
-		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], this.getWordsWithWordWalker( innerOrderedList.getFirst() ));
+		arrayAssert.itemsAreEqual([], outerWordsReturned);
+		arrayAssert.itemsAreEqual(['foo', 'bar', 'baz'], innerWordsReturned);
+
+		arrayAssert.itemsAreEqual(outerWordsReturned, outerRangesReturned);
+		arrayAssert.itemsAreEqual(innerWordsReturned, innerRangesReturned);
 	},
 
 	'test walking across a double nested list': function() {
 		var bot = this.editorBot,
+			wordObjectsReturned,
+			rangesReturned,
 			wordsReturned;
 		bot.setHtmlWithSelection(
 			'<ul>' +
@@ -162,14 +180,22 @@ bender.test( {
 				'</li>' +
 			'</ul>' );
 
-		wordsReturned = this.getWordsWithWordWalker(this.editor.editable().getFirst().getFirst() );
+		wordObjectsReturned = this.getWordObjectsWithWordWalker(this.editor.editable().getFirst().getFirst() );
+		rangesReturned = this.getWordRanges(wordObjectsReturned.ranges);
+		wordsReturned = wordObjectsReturned.words;
 
 		arrayAssert.itemsAreEqual(['foo'], wordsReturned);
+		arrayAssert.itemsAreEqual(wordsReturned, rangesReturned);
 	},
 
 	'test walking nested list wrapped with text nodes': function() {
 		var bot = this.editorBot,
-			wordsReturned,
+			outerWordObjectsReturned,
+			outerRangesReturned,
+			outerWordsReturned,
+			innerWordObjectsReturned,
+			innerRangesReturned,
+			innerWordsReturned,
 			outerUnorderedList,
 			innerOrderedList;
 		bot.setHtmlWithSelection(
@@ -184,14 +210,27 @@ bender.test( {
 
 		outerUnorderedList = this.editor.editable().getFirst();
 
+		outerWordObjectsReturned = this.getWordObjectsWithWordWalker( outerUnorderedList.getFirst() );
+		outerRangesReturned = this.getWordRanges(outerWordObjectsReturned.ranges);
+		outerWordsReturned = outerWordObjectsReturned.words;
+
 		innerOrderedList = outerUnorderedList.getFirst().getChild(1);
 
-		arrayAssert.itemsAreEqual(['foo', 'baz'], this.getWordsWithWordWalker( outerUnorderedList.getFirst() ));
-		arrayAssert.itemsAreEqual(['bar'], this.getWordsWithWordWalker( innerOrderedList.getFirst() ));
+		innerWordObjectsReturned = this.getWordObjectsWithWordWalker( innerOrderedList.getFirst() );
+		innerRangesReturned = this.getWordRanges(innerWordObjectsReturned.ranges);
+		innerWordsReturned = innerWordObjectsReturned.words;
+
+		arrayAssert.itemsAreEqual(['foo', 'baz'], outerWordsReturned);
+		arrayAssert.itemsAreEqual(['bar'], innerWordsReturned);
+
+		arrayAssert.itemsAreEqual(outerWordsReturned, outerRangesReturned);
+		arrayAssert.itemsAreEqual(innerWordsReturned, innerRangesReturned);
 	},
 
 	'test walking list item which has textnode with table sibling': function() {
 		var bot = this.editorBot,
+			wordObjectsReturned,
+			rangesReturned,
 			wordsReturned,
 			outerUnorderedList,
 			innerOrderedList;
@@ -217,11 +256,18 @@ bender.test( {
 
 		outerUnorderedList = this.editor.editable().getFirst();
 
-		arrayAssert.itemsAreEqual(['asdf'], this.getWordsWithWordWalker( outerUnorderedList.getFirst() ));
+		wordObjectsReturned = this.getWordObjectsWithWordWalker( outerUnorderedList.getFirst() );
+		rangesReturned = this.getWordRanges(wordObjectsReturned.ranges);
+		wordsReturned = wordObjectsReturned.words;
+
+		arrayAssert.itemsAreEqual(['asdf'], wordsReturned);
+		arrayAssert.itemsAreEqual(wordsReturned, rangesReturned);
 	},
 
 	'test it ignores spellcheck spans': function() {
 		var bot = this.editorBot,
+			wordObjectsReturned,
+			rangesReturned,
 			wordsReturned,
 			paragraphWithSpellCheckSpans;
 
@@ -231,14 +277,19 @@ bender.test( {
 
 		paragraphWithSpellCheckSpans = this.editor.editable().getFirst();
 
-		wordsReturned = this.getWordsWithWordWalker(paragraphWithSpellCheckSpans);
+		wordObjectsReturned = this.getWordObjectsWithWordWalker(paragraphWithSpellCheckSpans);
+		rangesReturned = this.getWordRanges(wordObjectsReturned.ranges);
+		wordsReturned = wordObjectsReturned.words;
 
 		arrayAssert.itemsAreEqual(['This', 'paragraph', 'has', 'a', 'in', 'it'], wordsReturned);
+		arrayAssert.itemsAreEqual(wordsReturned, rangesReturned);
 	},
 
 	'test walking paragraph with breaks and subscripts and superscripts': function() {
 		var bot = this.editorBot,
 			paragraphWithTags,
+			wordObjectsReturned,
+			rangesReturned,
 			wordsReturned;
 
 		bot.setHtmlWithSelection(
@@ -247,8 +298,11 @@ bender.test( {
 
 		paragraphWithTags = this.editor.editable().getFirst();
 
-		wordsReturned = this.getWordsWithWordWalker(paragraphWithTags);
+		wordObjectsReturned = this.getWordObjectsWithWordWalker(paragraphWithTags);
+		rangesReturned = this.getWordRanges(wordObjectsReturned.ranges);
+		wordsReturned = wordObjectsReturned.words;
 
 		arrayAssert.itemsAreEqual(['paragraph', 'break', 'superscript', 'paragraph', 'subscript'], wordsReturned);
+		arrayAssert.itemsAreEqual(wordsReturned, rangesReturned);
 	}
 } );


### PR DESCRIPTION
Adding the `if` checks in the returns of `WordWalker.getNextWord` caused an issue where if the word was an empty string, the loop would continue and this could cause a returned range to include multiple words.  This caused spellcheck spans to get wrapped around multiple words incorrectly, as well as potentially causing nested spellcheck spans. 

Instead, the responsibility of ignoring empty strings is moved to the functions where `WordWalker.getNextWord` is called.   This was already the case in `markTyposInRange`, and is now added to `getWords`, as well as the `getWordsWithWordWalker` function in the `wordwalker.js` test.
