### PR TITLE
Fix #41 - more responsive marking by using 0ms setTimeout 

### DIFF
--- a/bender.js
+++ b/bender.js
@@ -24,42 +24,42 @@
  */
 
 var config = {
-    applications: {
-        ckeditor: {
-            path: '.',
-            files: [
-                'ckeditor.js',
+	applications: {
+		ckeditor: {
+			path: '.',
+			files: [
+				'ckeditor.js',
 				'tests/polyfills/bind.js'
-            ]
-        }
-    },
+			]
+		}
+	},
 
-    framework: 'yui', // use for entire project
+	framework: 'yui', // use for entire project
 
-    plugins: [
-        'benderjs-yui',
-        'benderjs-jquery',
-        'benderjs-sinon',
-        'tests/_benderjs/ckeditor'
-    ],
+	plugins: [
+		'benderjs-yui',
+		'benderjs-jquery',
+		'benderjs-sinon',
+		'tests/_benderjs/ckeditor'
+	],
 
-    tests: {
-        nanospell: {
-            applications: [ 'ckeditor' ],
-            basePath: 'tests/',
-            paths: [
-                'smoke/**',
+	tests: {
+		nanospell: {
+			applications: [ 'ckeditor' ],
+			basePath: 'tests/',
+			paths: [
+				'smoke/**',
 				'typowalking/**',
-                'spellchecking/**',
+				'spellchecking/**',
 				'suggestions/**',
-                '!**/_*/**'
-            ],
-            // Latest of the old API (1.8.3)
-            // Latest of the 1.* branch
-            // Latest of the 2.* branch
-            jQuery: [ '1.8.3', '1.11.1', '2.1.1' ]
-        }
-    }
+				'!**/_*/**'
+			],
+			// Latest of the old API (1.8.3)
+			// Latest of the 1.* branch
+			// Latest of the 2.* branch
+			jQuery: [ '1.8.3', '1.11.1', '2.1.1' ]
+		}
+	}
 
 };
 

--- a/bender.js
+++ b/bender.js
@@ -28,7 +28,8 @@ var config = {
         ckeditor: {
             path: '.',
             files: [
-                'ckeditor.js'
+                'ckeditor.js',
+				'tests/polyfills/bind.js'
             ]
         }
     },

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -443,7 +443,7 @@
 				}
 				return true;
 			});
-			editor.on(EVENT_NAMES.START_RENDER, render, self);
+			editor.on(EVENT_NAMES.START_RENDER, scheduleRender, self);
 			editor.on(EVENT_NAMES.START_SCAN_WORDS, scanWords, self);
 			editor.on(EVENT_NAMES.START_CHECK_WORDS, checkWords, self);
 
@@ -731,6 +731,10 @@
 
 			function resolveAjaxHandler() {
 				return '/spellcheck/nano/';
+			}
+
+			function scheduleRender(event) {
+				setTimeout(render.bind(this, event), 0);
 			}
 
 			function render(event) {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -945,7 +945,9 @@ if (!Function.prototype.bind) {
 			}
 
 			function ignoreWord(target, word, all) {
-				var i;
+				var allInstances,
+					i,
+					numInstances;
 				if (all) {
 					ignorecache[word.toLowerCase()] = true;
 					for (i in suggestionscache) {
@@ -953,8 +955,9 @@ if (!Function.prototype.bind) {
 							delete suggestionscache[i];
 						}
 					}
-					var allInstances = editor.document.find('span.nanospell-typo');
-					for (i = 0; i < allInstances.count(); i++) {
+					allInstances = editor.document.find('span.nanospell-typo');
+					numInstances = allInstances.count();
+					for (i = 0; i < numInstances; i++) {
 						var item = allInstances.getItem(i);
 						var text = item.getText();
 						if (text == word) {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -584,7 +584,7 @@
 			}
 
 			function scheduleScanWords(event) {
-				setTimeout(scanWords.bind(this, event), 0);
+				setTimeout(scanWords, 0, event);
 			}
 
 			function scanWords(event) {
@@ -737,7 +737,7 @@
 			}
 
 			function scheduleRender(event) {
-				setTimeout(render.bind(this, event), 0);
+				setTimeout(render, 0, event);
 			}
 
 			function render(event) {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -664,7 +664,6 @@
 				var blockList = event.data.blockList;
 				var url = resolveAjaxHandler();
 				var callback = function (data) {
-					var selectionStart = editor.getSelection().getStartElement();
 					var rootElement;
 					parseRpc(data, words);
 
@@ -672,7 +671,6 @@
 						rootElement = blockList[i];
 						editor.fire(EVENT_NAMES.START_RENDER, {
 							root: rootElement,
-							needsBookmarkCreated: selectionStart ? rootElement.contains(selectionStart) || rootElement.equals(selectionStart) : null,
 						});
 					}
 				};
@@ -739,7 +737,8 @@
 
 			function render(event) {
 				var rootElement = event.data.root,
-					needsBookmarkCreated = event.data.needsBookmarkCreated,
+					selectionStart = editor.getSelection().getStartElement(),
+					needsBookmarkCreated = selectionStart ? rootElement.contains(selectionStart) || rootElement.equals(selectionStart) : null,
 					bookmarks;
 
 				if (needsBookmarkCreated) {
@@ -852,7 +851,6 @@
 			}
 
 			function startCheckOrMarkWords(words, blockList) {
-				var selectionStart = editor.getSelection().getStartElement();
 				if (words.length > 0) {
 					editor.fire(EVENT_NAMES.START_CHECK_WORDS, {
 						words: words,
@@ -867,7 +865,6 @@
 							EVENT_NAMES.START_RENDER,
 							{
 								root: rootElement,
-								needsBookmarkCreated: selectionStart ? rootElement.contains(selectionStart) || rootElement.equals(selectionStart) : null,
 							});
 
 					}

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -444,7 +444,7 @@
 				return true;
 			});
 			editor.on(EVENT_NAMES.START_RENDER, scheduleRender, self);
-			editor.on(EVENT_NAMES.START_SCAN_WORDS, scanWords, self);
+			editor.on(EVENT_NAMES.START_SCAN_WORDS, scheduleScanWords, self);
 			editor.on(EVENT_NAMES.START_CHECK_WORDS, checkWords, self);
 
 			setUpContextMenu(editor, this.path);
@@ -580,6 +580,10 @@
 
 					editor.fire(EVENT_NAMES.START_SCAN_WORDS, rootElement);
 				}
+			}
+
+			function scheduleScanWords(event) {
+				setTimeout(scanWords.bind(this, event), 0);
 			}
 
 			function scanWords(event) {

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -17,6 +17,36 @@
  * A huge thanks To Frederico Knabben and all contributirs to CKEditor for releasing and maintaining a world class javascript HTML Editor.
  * FCK and CKE have enabled a new generation of online software , without your excelent work this project would be pointless.
  */
+
+// polyfill for non-bind environments
+if (!Function.prototype.bind) {
+	Function.prototype.bind = function(oThis) {
+		if (typeof this !== 'function') {
+			// closest thing possible to the ECMAScript 5
+			// internal IsCallable function
+			throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+		}
+
+		var aArgs   = Array.prototype.slice.call(arguments, 1),
+			fToBind = this,
+			fNOP    = function() {},
+			fBound  = function() {
+				return fToBind.apply(this instanceof fNOP
+						? this
+						: oThis,
+					aArgs.concat(Array.prototype.slice.call(arguments)));
+			};
+
+		if (this.prototype) {
+			// Function.prototype doesn't have a prototype property
+			fNOP.prototype = this.prototype;
+		}
+		fBound.prototype = new fNOP();
+
+		return fBound;
+	};
+}
+
 (function () {
 	'use strict';
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -946,7 +946,7 @@
 
 						if (retval) {
 							var currentData = self.clearAllSpellCheckingSpansFromString(this.getSnapshot()),
-								prevData = self.clearAllSpellCheckingSpansFromString(this._.previousValue);
+								prevData = this._.previousValue;
 
 							retval = (retval && (prevData !== currentData))
 						}

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -18,35 +18,6 @@
  * FCK and CKE have enabled a new generation of online software , without your excelent work this project would be pointless.
  */
 
-// polyfill for non-bind environments
-if (!Function.prototype.bind) {
-	Function.prototype.bind = function(oThis) {
-		if (typeof this !== 'function') {
-			// closest thing possible to the ECMAScript 5
-			// internal IsCallable function
-			throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
-		}
-
-		var aArgs   = Array.prototype.slice.call(arguments, 1),
-			fToBind = this,
-			fNOP    = function() {},
-			fBound  = function() {
-				return fToBind.apply(this instanceof fNOP
-						? this
-						: oThis,
-					aArgs.concat(Array.prototype.slice.call(arguments)));
-			};
-
-		if (this.prototype) {
-			// Function.prototype doesn't have a prototype property
-			fNOP.prototype = this.prototype;
-		}
-		fBound.prototype = new fNOP();
-
-		return fBound;
-	};
-}
-
 (function () {
 	'use strict';
 

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -772,8 +772,10 @@ if (!Function.prototype.bind) {
 			function render(event) {
 				var rootElement = event.data.root,
 					selectionStart = editor.getSelection().getStartElement(),
-					needsBookmarkCreated = selectionStart ? rootElement.contains(selectionStart) || rootElement.equals(selectionStart) : null,
+					needsBookmarkCreated,
 					bookmarks;
+
+				needsBookmarkCreated = selectionStart ? rootElement.contains(selectionStart) || rootElement.equals(selectionStart) : null;
 
 				if (needsBookmarkCreated) {
 					editor.lockSelection();

--- a/tests/polyfills/bind.js
+++ b/tests/polyfills/bind.js
@@ -1,0 +1,29 @@
+// polyfill for non-bind environments
+// basically, Phantom.
+if (!Function.prototype.bind) {
+	Function.prototype.bind = function(oThis) {
+		if (typeof this !== 'function') {
+			// closest thing possible to the ECMAScript 5
+			// internal IsCallable function
+			throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+		}
+
+		var aArgs   = Array.prototype.slice.call(arguments, 1),
+			fToBind = this,
+			fNOP    = function() {},
+			fBound  = function() {
+				return fToBind.apply(this instanceof fNOP
+						? this
+						: oThis,
+					aArgs.concat(Array.prototype.slice.call(arguments)));
+			};
+
+		if (this.prototype) {
+			// Function.prototype doesn't have a prototype property
+			fNOP.prototype = this.prototype;
+		}
+		fBound.prototype = new fNOP();
+
+		return fBound;
+	};
+}

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -66,8 +66,9 @@
 				// splits the document into blocks, all events other than
 				// "startScanWords" and "startCheckWordsAjax" will be fired twice.
 				// The `render` function which fires "spellCheckComplete" is now
-				// scheduled as a 0 ms timeout.  "startRender" fires before the scheduling of that
-				// function.
+				// scheduled as a 0 ms timeout.  "startRender" fires to trigger
+				// the scheduling of that timeout, but the timeouts do not
+				// actually fire until all of them have been registered
 				observer.assert(["startScanWords", "startCheckWordsAjax", "startRender", "startRender", "spellCheckComplete", "spellCheckComplete"]);
 
 				// make a new observer to clear the events

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -68,7 +68,7 @@
 				// The `render` function which fires "spellCheckComplete" is now
 				// scheduled as a 0 ms timeout.  "startRender" fires to trigger
 				// the scheduling of that timeout, but the timeouts do not
-				// actually fire until all of them have been registered
+				// actually fire until all of them have been registered.
 				observer.assert(["startScanWords", "startCheckWordsAjax", "startRender", "startRender", "spellCheckComplete", "spellCheckComplete"]);
 
 				// make a new observer to clear the events

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -65,7 +65,10 @@
 				// first run checks the whole document.  Since the spellcheck first
 				// splits the document into blocks, all events other than
 				// "startScanWords" and "startCheckWordsAjax" will be fired twice.
-				observer.assert(["startScanWords", "startCheckWordsAjax", "startRender", "spellCheckComplete", "startRender", "spellCheckComplete"]);
+				// The `render` function which fires "spellCheckComplete" is now
+				// scheduled as a 0 ms timeout.  "startRender" fires before the scheduling of that
+				// function.
+				observer.assert(["startScanWords", "startCheckWordsAjax", "startRender", "startRender", "spellCheckComplete", "spellCheckComplete"]);
 
 				// make a new observer to clear the events
 

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -125,7 +125,7 @@
 
 			function completeFirstSpellcheck() {
 
-				observer.assert(["startScanWords", "startCheckWordsAjax", "startRender", "spellCheckComplete", "startRender", "spellCheckComplete"]);
+				observer.assert(["startScanWords", "startCheckWordsAjax", "startRender", "startRender", "spellCheckComplete", "spellCheckComplete"]);
 
 				// set outer li to show that a spellcheck is in progress
 				outer.setCustomData('spellCheckInProgress', true);


### PR DESCRIPTION
Put scanning & marking inside a setTimeout, make minor improvements everywhere.  

Other low hanging fruit:  

- Removed the fact that the dirty snapshot was being cleaned twice. 
- fixed a for loop that was re-calculating the count on every run.  