### PR TITLE
Fix most of #36 - initial spellcheck is now batched by word limit (roughly)

### DIFF
--- a/bender.js
+++ b/bender.js
@@ -29,7 +29,8 @@ var config = {
 			path: '.',
 			files: [
 				'ckeditor.js',
-				'tests/polyfills/bind.js'
+				'tests/polyfills/bind.js',
+				'node_modules/chance/dist/chance.min.js'
 			]
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "benderjs-cli": "^0.1.1",
     "benderjs-jquery": "^0.3.0",
     "benderjs-sinon": "^0.3.1",
-    "benderjs-yui": "^0.3.3"
+    "benderjs-yui": "^0.3.3",
+    "chance": "^1.0.4"
   }
 }

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -20,8 +20,6 @@
 
 (function () {
 	'use strict';
-
-	var maxRequest = 200;
 	var editorHasFocus = false;
 	var spellDelay = 250;
 	var spellFastAfterSpacebar = true;

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -382,7 +382,8 @@
 			}
 			lang = this.settings.dictionary || lang;
 			this.suggestions = new SuggestionsStorage();
-			this.settings.wordLimitPerRequest = this.settings.wordLimitPerRequest || DEFAULT_WORD_LIMIT_PER_REQUEST;
+			// set the maximum number of block elements spellchecked per AJAX request
+			self.settings.wordLimitPerRequest = self.settings.wordLimitPerRequest || DEFAULT_WORD_LIMIT_PER_REQUEST;
 			editor.addCommand('nanospell', {
 				exec: function (editor) {
 					if (!commandIsActive) {
@@ -825,7 +826,7 @@
 					block.setCustomData('spellCheckInProgress', true);
 					combinedWords = combinedWords.concat(getWords(block));
 					blockList.push(block);
-					if (combinedWords.length > this.settings.wordLimitPerRequest) {
+					if (combinedWords.length > self.settings.wordLimitPerRequest) {
 						startCheckOrMarkWords(getUnknownWords(combinedWords.join(' ')), blockList);
 						combinedWords = [];
 						blockList = [];

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -807,6 +807,7 @@
 					if (!uniqueWords[word] && self.validWordToken(word) && (typeof(spellcache[word]) === 'undefined')) {
 						words.push(word);
 						uniqueWords[word] = true;
+						spellcache[word] = true; // mark the word as correct, when the RPC returns, it will set this properly.
 					}
 				}
 				return words;

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -826,7 +826,7 @@
 					block.setCustomData('spellCheckInProgress', true);
 					combinedWords = combinedWords.concat(getWords(block));
 					blockList.push(block);
-					if (combinedWords.length > self.settings.wordLimitPerRequest) {
+					if (combinedWords.length >= self.settings.wordLimitPerRequest) {
 						startCheckOrMarkWords(getUnknownWords(combinedWords.join(' ')), blockList);
 						combinedWords = [];
 						blockList = [];

--- a/plugins/nanospell/plugin.js
+++ b/plugins/nanospell/plugin.js
@@ -48,8 +48,7 @@
 		SPELLCHECK_COMPLETE: 'spellCheckComplete',
 		SPELLCHECK_ABORT: 'spellCheckAbort'
 	};
-	var BLOCK_REQUEST_LIMIT = 5;
-	var WORD_REQUEST_LIMIT = 200;
+	var DEFAULT_WORD_LIMIT_PER_REQUEST = 200;
 
 	function normalizeQuotes(word) {
 		return word.replace(/[\u2018\u2019]/g, "'");
@@ -383,9 +382,7 @@
 			}
 			lang = this.settings.dictionary || lang;
 			this.suggestions = new SuggestionsStorage();
-			// set the maximum number of block elements spellchecked per AJAX request
-			BLOCK_REQUEST_LIMIT = this.settings.blockRequestLimit || BLOCK_REQUEST_LIMIT;
-			WORD_REQUEST_LIMIT = this.settings.wordrequestLimit || WORD_REQUEST_LIMIT;
+			this.settings.wordLimitPerRequest = this.settings.wordLimitPerRequest || DEFAULT_WORD_LIMIT_PER_REQUEST;
 			editor.addCommand('nanospell', {
 				exec: function (editor) {
 					if (!commandIsActive) {
@@ -828,7 +825,7 @@
 					block.setCustomData('spellCheckInProgress', true);
 					combinedWords = combinedWords.concat(getWords(block));
 					blockList.push(block);
-					if (combinedWords.length > WORD_REQUEST_LIMIT) {
+					if (combinedWords.length > this.settings.wordLimitPerRequest) {
 						startCheckOrMarkWords(getUnknownWords(combinedWords.join(' ')), blockList);
 						combinedWords = [];
 						blockList = [];

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -186,6 +186,27 @@
 			});
 
 			wait();
+		},
+		'test repeat words do not get checked again': function () {
+
+			var bot = this.editorBot,
+				editor = bot.editor,
+				resumeAfter = bender.tools.resumeAfter,
+				observer = observeSpellCheckEvents(editor),
+				paragraph = makeFakeParagraphTag(200);
+
+			bot.setHtmlWithSelection(paragraph + paragraph); // two identical paragraphs at the limit.
+
+			resumeAfter(editor, 'spellCheckComplete', function () {
+				// 200 words = 1 ajax call
+				observer.assertAjaxCalls(1);
+
+				// reset observer
+				observer = observeSpellCheckEvents(editor);
+
+			});
+
+			wait();
 		}
 	});
 

--- a/tests/smoke/events.js
+++ b/tests/smoke/events.js
@@ -8,10 +8,14 @@
 		config: {
 			enterMode: CKEDITOR.ENTER_P,
 			nanospell: {
-				blockRequestLimit: 5
+				wordLimitPerRequest: 200
 			}
 		}
 	};
+
+	function makeFakeParagraphTag(numWords) {
+		return '<p>' + chance.sentence({ words: numWords }) + '</p>';
+	}
 
 	bender.test({
 		setUp: function () {
@@ -54,7 +58,7 @@
 
 			wait();
 		},
-		'test future spellchecks only check the current element': function() {
+		'test future spellchecks only check the current element': function () {
 			var bot = this.editorBot,
 				editor = bot.editor,
 				resumeAfter = bender.tools.resumeAfter,
@@ -104,7 +108,7 @@
 			// wait for the first spellcheck
 			wait();
 		},
-		'test spellcheck on element does not occur when parent block has spellcheck in progress': function() {
+		'test spellcheck on element does not occur when parent block has spellcheck in progress': function () {
 			var bot = this.editorBot,
 				editor = bot.editor,
 				resumeAfter = bender.tools.resumeAfter,
@@ -152,38 +156,36 @@
 				observer.assert(["spellCheckAbort"]);
 			}
 		},
-		'test spellcheck can batch ajax calls for a document with multiple blocks': function() {
+		'test spellcheck can batch ajax calls for a document with multiple blocks exceeding the word limit': function () {
+
 			var bot = this.editorBot,
 				editor = bot.editor,
 				resumeAfter = bender.tools.resumeAfter,
-				observer = observeSpellCheckEvents(editor),
-				fiveBlockHtml = '<p>This</p><p>is</p><ul><li>five</li><li>block</li></ul><p>test</p> ^',
-				sixBlockHtml = '<p>This</p><p>is</p><p>a</p><ul><li>six</li><li>block</li></ul><p>one</p> ^';
+				observer = observeSpellCheckEvents(editor);
 
-				bot.setHtmlWithSelection(fiveBlockHtml);
+			bot.setHtmlWithSelection(makeFakeParagraphTag(100) + makeFakeParagraphTag(100));
 
-				resumeAfter(editor, 'spellCheckComplete', function() {
-					// spellcheck with 5 blocks should make 1 AJAX call
-					observer.assertAjaxCalls(1);
+			resumeAfter(editor, 'spellCheckComplete', function () {
+				// 200 words = 1 ajax call
+				observer.assertAjaxCalls(1);
 
-					// reset observer
-					observer = observeSpellCheckEvents(editor);
+				// reset observer
+				observer = observeSpellCheckEvents(editor);
 
-					// reset plugin
-					editor.execCommand('nanospellReset');
+				// reset plugin
+				editor.execCommand('nanospellReset');
 
-					bot.setHtmlWithSelection(sixBlockHtml);
+				// now we have 4 blocks, 100 words each
+				bot.setHtmlWithSelection(makeFakeParagraphTag(100) + makeFakeParagraphTag(100) + makeFakeParagraphTag(100) + makeFakeParagraphTag(100));
 
-					resumeAfter(editor, 'spellCheckComplete', function() {
-						// spellcheck with 6 blocks should make 2 AJAX calls
-						observer.assertAjaxCalls(2);
-					});
-
-					wait();
+				resumeAfter(editor, 'spellCheckComplete', function () {
+					observer.assertAjaxCalls(2);
 				});
 
 				wait();
+			});
 
+			wait();
 		}
 	});
 
@@ -193,7 +195,7 @@
 	 https://github.com/ckeditor/ckeditor-dev/blob/12f0de314fd6fbee0bc4d35d541123d283fdecc9/tests/plugins/filetools/fileloader.js#L131
 	 */
 	function observeSpellCheckEvents(editor) {
-		var observer = {events: []};
+		var observer = { events: [] };
 
 		function stdObserver(evt) {
 			observer.events.push(evt);
@@ -223,7 +225,7 @@
 				i,
 				root;
 
-			for (i=0; i<events.length; i++) {
+			for (i = 0; i < events.length; i++) {
 				event = events[i];
 				if (event.name === 'spellCheckComplete') {
 					continue;
@@ -236,13 +238,13 @@
 			}
 		};
 
-		observer.assertAjaxCalls = function(expected) {
+		observer.assertAjaxCalls = function (expected) {
 			var events = observer.events,
 				ajaxCalls = 0,
 				event,
 				i;
 
-			for (i=0; i<events.length; i++) {
+			for (i = 0; i < events.length; i++) {
 				event = events[i];
 				if (event.name === 'startCheckWordsAjax')
 					ajaxCalls++;


### PR DESCRIPTION
The initial spellcheck now selects blocks until the word limit is exceeded.

This prevents some degenerate cases (for example single word per cell tables) 

This also fixes a case where repeat words across different blocks in the same batch will be checked multiple times.  